### PR TITLE
Re-miniAOD production

### DIFF
--- a/Analysis/python/MicroAODCustomize.py
+++ b/Analysis/python/MicroAODCustomize.py
@@ -37,6 +37,10 @@ class MicroAODCustomize(fggMicroAODCustomize):
         if "WJetsToLNu" in self.datasetName:
             process.myPreselectedPhotons.filter = cms.bool(True)
             
+    # signal specific customization
+    def customizeSignal(self,process):
+        process.flashggGenPhotonsExtra.defaultType = 1
+
 
 # customization object
 customize = MicroAODCustomize()

--- a/MetaData/data/EXOGenGrav_v1/datasets.json
+++ b/MetaData/data/EXOGenGrav_v1/datasets.json
@@ -1,0 +1,6275 @@
+{
+    "/RSGravitonToGG_kMpl001_M_1000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f086f4b6554d2011540220fabbfe2a15/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211512/0000/RSGravitonToGammaGamma_kMpl001_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211512/0000/RSGravitonToGammaGamma_kMpl001_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_1125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5774736356a24209076e9127d55d09db/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211510/0000/RSGravitonToGammaGamma_kMpl001_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211510/0000/RSGravitonToGammaGamma_kMpl001_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_1250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-307595deb326745055756c1ce1396e62/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211510/0000/RSGravitonToGammaGamma_kMpl001_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211510/0000/RSGravitonToGammaGamma_kMpl001_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_1375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f19c79e53ec0701ded12218369f44428/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211511/0000/RSGravitonToGammaGamma_kMpl001_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211511/0000/RSGravitonToGammaGamma_kMpl001_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_1500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5497386d27a804c309c16a52c0709e37/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211505/0000/RSGravitonToGammaGamma_kMpl001_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211505/0000/RSGravitonToGammaGamma_kMpl001_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_1625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ad54efdeefbdb950c914d4d3cc58e58b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211512/0000/RSGravitonToGammaGamma_kMpl001_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_1750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-82dfb7fd9e03e48da3abbf64bf2d8cda/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211511/0000/RSGravitonToGammaGamma_kMpl001_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_1875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-40a77c773b6a3f18256bdd1df98bfccf/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211511/0000/RSGravitonToGammaGamma_kMpl001_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211511/0000/RSGravitonToGammaGamma_kMpl001_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_2000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-edd63071a725d22dc30a2985ab9043c0/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211524/0000/RSGravitonToGammaGamma_kMpl001_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211524/0000/RSGravitonToGammaGamma_kMpl001_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_2125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-39d9fa624d2a648abb6e89dcc0bebec1/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211524/0000/RSGravitonToGammaGamma_kMpl001_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211524/0000/RSGravitonToGammaGamma_kMpl001_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_2250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-848d5d96343dc8d5ecab7b3400075483/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211524/0000/RSGravitonToGammaGamma_kMpl001_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211524/0000/RSGravitonToGammaGamma_kMpl001_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_2375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-721a65e317001d9fef943c698e238249/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211539/0000/RSGravitonToGammaGamma_kMpl001_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211539/0000/RSGravitonToGammaGamma_kMpl001_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_2500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7878d8d04318293bb2ff22ba96678d0c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211539/0000/RSGravitonToGammaGamma_kMpl001_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211539/0000/RSGravitonToGammaGamma_kMpl001_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_2625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a5805fc878c5b31a49c2df6792babc96/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211539/0000/RSGravitonToGammaGamma_kMpl001_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211539/0000/RSGravitonToGammaGamma_kMpl001_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_2750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a3500062c17772e5fb94f3134c15e36a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211553/0000/RSGravitonToGammaGamma_kMpl001_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211553/0000/RSGravitonToGammaGamma_kMpl001_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_2875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-4328b1b4d334daf3906a83128f9c3a39/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211553/0000/RSGravitonToGammaGamma_kMpl001_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211553/0000/RSGravitonToGammaGamma_kMpl001_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_3000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a6fc2b0090a35952c8d0907cb6e28599/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211553/0000/RSGravitonToGammaGamma_kMpl001_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211553/0000/RSGravitonToGammaGamma_kMpl001_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_3625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-99a89a430d90e64ee0c9ed46d1dc0554/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211612/0000/RSGravitonToGammaGamma_kMpl001_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211612/0000/RSGravitonToGammaGamma_kMpl001_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_3750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a2318f8726492cdc3110d79b76b22f2d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211612/0000/RSGravitonToGammaGamma_kMpl001_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211612/0000/RSGravitonToGammaGamma_kMpl001_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_3875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d27a5a0c7c799698a8d446acef11c325/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211627/0000/RSGravitonToGammaGamma_kMpl001_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211627/0000/RSGravitonToGammaGamma_kMpl001_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_4000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9a754f761b82e54ed1a91a585632752c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211627/0000/RSGravitonToGammaGamma_kMpl001_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211627/0000/RSGravitonToGammaGamma_kMpl001_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_4125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-921394d3dcd1dfb1549d71d34fcb89d1/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211627/0000/RSGravitonToGammaGamma_kMpl001_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211627/0000/RSGravitonToGammaGamma_kMpl001_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_4250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3793b6ae074f0cc145ea238993627a2f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211638/0000/RSGravitonToGammaGamma_kMpl001_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211638/0000/RSGravitonToGammaGamma_kMpl001_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_4500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7e7ace061e988505c43947d80740c14a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211635/0000/RSGravitonToGammaGamma_kMpl001_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211635/0000/RSGravitonToGammaGamma_kMpl001_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_4625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e811cd4b6bc9634650b75c08c517c233/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211638/0000/RSGravitonToGammaGamma_kMpl001_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211638/0000/RSGravitonToGammaGamma_kMpl001_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_4750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-59350d1b2e95e7f6d0ecbfe2062ad280/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211638/0000/RSGravitonToGammaGamma_kMpl001_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211638/0000/RSGravitonToGammaGamma_kMpl001_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_5000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-70b00b36ec3aacbb2e65d04d7a9e4a03/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211643/0000/RSGravitonToGammaGamma_kMpl001_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211643/0000/RSGravitonToGammaGamma_kMpl001_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-46578f32b01fe69ee16a9d5b8f801333/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211643/0000/RSGravitonToGammaGamma_kMpl001_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_5125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fd809ceb6a6bf5e997af1300d94a3d16/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211648/0000/RSGravitonToGammaGamma_kMpl001_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211648/0000/RSGravitonToGammaGamma_kMpl001_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_5250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-06b3643af0c504734d469ddd200a5d9f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211649/0000/RSGravitonToGammaGamma_kMpl001_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211649/0000/RSGravitonToGammaGamma_kMpl001_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_5375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-325fa9536bf97126e0dd40e2931bbc17/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211651/0000/RSGravitonToGammaGamma_kMpl001_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211651/0000/RSGravitonToGammaGamma_kMpl001_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_5500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3134b68a23c1e08e9141395f2870de05/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211652/0000/RSGravitonToGammaGamma_kMpl001_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211652/0000/RSGravitonToGammaGamma_kMpl001_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_5625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0235eadaf71a2fafbebf70c8c28c35d3/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211652/0000/RSGravitonToGammaGamma_kMpl001_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_5750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-98019df48fec37180357cc757fe77a09/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211659/0000/RSGravitonToGammaGamma_kMpl001_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211659/0000/RSGravitonToGammaGamma_kMpl001_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_5875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ba8751d893f48fffcb38fa014c39809f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211659/0000/RSGravitonToGammaGamma_kMpl001_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211659/0000/RSGravitonToGammaGamma_kMpl001_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_6000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9816a08b531ea9d38124d67509d44dc6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211659/0000/RSGravitonToGammaGamma_kMpl001_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_6125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-be44ed904d7c154416b588d07fa6e7d6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211701/0000/RSGravitonToGammaGamma_kMpl001_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_6250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e38a07d0312f5b7a128ba2dabc54d50e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211701/0000/RSGravitonToGammaGamma_kMpl001_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b4d61cf23245fa59dbd030718aabd100/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211704/0000/RSGravitonToGammaGamma_kMpl001_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211704/0000/RSGravitonToGammaGamma_kMpl001_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_6375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-326d365d3a12119f826c12f588e9a802/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211705/0000/RSGravitonToGammaGamma_kMpl001_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211705/0000/RSGravitonToGammaGamma_kMpl001_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_6500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-98a4d25f211db5d87f8cf31660764c46/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211705/0000/RSGravitonToGammaGamma_kMpl001_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211705/0000/RSGravitonToGammaGamma_kMpl001_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_6625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-84478d7532f0ad3d8ef183440345dd37/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211720/0000/RSGravitonToGammaGamma_kMpl001_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211720/0000/RSGravitonToGammaGamma_kMpl001_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_6750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-408e427fa76b7f515e083e3a39f93618/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211726/0000/RSGravitonToGammaGamma_kMpl001_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211726/0000/RSGravitonToGammaGamma_kMpl001_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl001_M_6875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ec7e24bf81dddebddd2bf9a181aaef5d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211726/0000/RSGravitonToGammaGamma_kMpl001_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211726/0000/RSGravitonToGammaGamma_kMpl001_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_7000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f3e47a4221cfe784a497935cb33c60bd/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211724/0000/RSGravitonToGammaGamma_kMpl001_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211724/0000/RSGravitonToGammaGamma_kMpl001_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-75979911f1f0646a00ca003b02f8c878/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211725/0000/RSGravitonToGammaGamma_kMpl001_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211725/0000/RSGravitonToGammaGamma_kMpl001_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl001_M_875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1a4dbe4a2c37d9878c2637008ca2cf1d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211727/0000/RSGravitonToGammaGamma_kMpl001_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl001_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211727/0000/RSGravitonToGammaGamma_kMpl001_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_1000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-186927d0b2c879d94d6bac7914600e2c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211726/0000/RSGravitonToGammaGamma_kMpl005_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211726/0000/RSGravitonToGammaGamma_kMpl005_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_1125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8d2ea843ffc4d8f1b8661da0b9fa4d10/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211726/0000/RSGravitonToGammaGamma_kMpl005_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211726/0000/RSGravitonToGammaGamma_kMpl005_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_1250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5d6e8c5364e15ba73003fbdc966bb3a5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211737/0000/RSGravitonToGammaGamma_kMpl005_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211737/0000/RSGravitonToGammaGamma_kMpl005_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_1375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7300cf3453c856b9457259b4e15ffbaf/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211737/0000/RSGravitonToGammaGamma_kMpl005_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211737/0000/RSGravitonToGammaGamma_kMpl005_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_1500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-16e0459df774045fef60345b40fe3dce/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211739/0000/RSGravitonToGammaGamma_kMpl005_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211739/0000/RSGravitonToGammaGamma_kMpl005_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_1625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-405cb4113fed639fd4e87e62d5be9820/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211744/0000/RSGravitonToGammaGamma_kMpl005_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211744/0000/RSGravitonToGammaGamma_kMpl005_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_1750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6dfd102ed4f8b2a2a04e7339cf95471b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211744/0000/RSGravitonToGammaGamma_kMpl005_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211744/0000/RSGravitonToGammaGamma_kMpl005_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_1875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-dee9c8e61c486746a1a4f6570a2651c3/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211743/0000/RSGravitonToGammaGamma_kMpl005_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211743/0000/RSGravitonToGammaGamma_kMpl005_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_2000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fbf0224e10f6b7c23ed946689ec0c55a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211744/0000/RSGravitonToGammaGamma_kMpl005_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_2125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6d1832645a0891dc16f9d6c90a4f4248/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211744/0000/RSGravitonToGammaGamma_kMpl005_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211744/0000/RSGravitonToGammaGamma_kMpl005_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_2250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6383297b85426bdf6e850201487fb26a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211750/0000/RSGravitonToGammaGamma_kMpl005_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211750/0000/RSGravitonToGammaGamma_kMpl005_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_2375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0b248e6a965d9e431eb0bf4c6b449256/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211750/0000/RSGravitonToGammaGamma_kMpl005_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211750/0000/RSGravitonToGammaGamma_kMpl005_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_2500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-056b0de79eeae0ece26ba5ff99da9cdc/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211751/0000/RSGravitonToGammaGamma_kMpl005_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211751/0000/RSGravitonToGammaGamma_kMpl005_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_2625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-dcd4efbb2d19560c0ea55ae484369cf9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211759/0000/RSGravitonToGammaGamma_kMpl005_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211759/0000/RSGravitonToGammaGamma_kMpl005_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_2750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-4b94fbcbb5313d6b951e51e8a8bed3e9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211810/0000/RSGravitonToGammaGamma_kMpl005_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211810/0000/RSGravitonToGammaGamma_kMpl005_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_2875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5556395bc532a57eb9a92b030214bdeb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211759/0000/RSGravitonToGammaGamma_kMpl005_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211759/0000/RSGravitonToGammaGamma_kMpl005_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_3000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a9c23ebe096842d8f281cd1740c568fb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211802/0000/RSGravitonToGammaGamma_kMpl005_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211802/0000/RSGravitonToGammaGamma_kMpl005_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_3500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8a3731c382e553c731f43c619bcf5370/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211801/0000/RSGravitonToGammaGamma_kMpl005_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_3625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d3b3336dd08c858dcfa5c5106ff9ca07/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211810/0000/RSGravitonToGammaGamma_kMpl005_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211810/0000/RSGravitonToGammaGamma_kMpl005_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_3750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cdddaa40a58d607443909361972c66c0/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211810/0000/RSGravitonToGammaGamma_kMpl005_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211810/0000/RSGravitonToGammaGamma_kMpl005_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_3875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1d295e6276c84bc3beb5d334a4ea94dc/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211813/0000/RSGravitonToGammaGamma_kMpl005_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211813/0000/RSGravitonToGammaGamma_kMpl005_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_4000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c49a5480b77033e1f0dca99c7604e4fa/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211820/0000/RSGravitonToGammaGamma_kMpl005_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211820/0000/RSGravitonToGammaGamma_kMpl005_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_4125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3acb7326514f560c75030d678fa54a03/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211815/0000/RSGravitonToGammaGamma_kMpl005_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211815/0000/RSGravitonToGammaGamma_kMpl005_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_4250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-34b39a17409f7caf8c85cb3d81065fa2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211821/0000/RSGravitonToGammaGamma_kMpl005_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_4375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2944c28a33794b73d0018966456ce8a7/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211829/0000/RSGravitonToGammaGamma_kMpl005_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211829/0000/RSGravitonToGammaGamma_kMpl005_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_4500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6db2499091c9f210d1ef72d5e5302788/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211829/0000/RSGravitonToGammaGamma_kMpl005_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211829/0000/RSGravitonToGammaGamma_kMpl005_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_4625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7dde85477279fb4880b4a0e282ca9be5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211830/0000/RSGravitonToGammaGamma_kMpl005_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211830/0000/RSGravitonToGammaGamma_kMpl005_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_4750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-715f68705e7f8cccfd12cd0a2f403f92/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211827/0000/RSGravitonToGammaGamma_kMpl005_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211827/0000/RSGravitonToGammaGamma_kMpl005_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_4875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f1a03d57dafe4346218b14f24798bdee/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211839/0000/RSGravitonToGammaGamma_kMpl005_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211839/0000/RSGravitonToGammaGamma_kMpl005_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-71fc6722d47ba4bb297bffedca8c3358/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211831/0000/RSGravitonToGammaGamma_kMpl005_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211831/0000/RSGravitonToGammaGamma_kMpl005_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_5125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-acd617119d34fe2a0cb4331f02876b84/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211839/0000/RSGravitonToGammaGamma_kMpl005_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211839/0000/RSGravitonToGammaGamma_kMpl005_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_5250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-275e22029a4a5a0c154339847bc12e35/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211842/0000/RSGravitonToGammaGamma_kMpl005_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211842/0000/RSGravitonToGammaGamma_kMpl005_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_5500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6274ef57d65527fd505d8b134f6cacf9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211843/0000/RSGravitonToGammaGamma_kMpl005_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211843/0000/RSGravitonToGammaGamma_kMpl005_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_5625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-072e1811e00c7026b54058e6d42addba/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211846/0000/RSGravitonToGammaGamma_kMpl005_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211846/0000/RSGravitonToGammaGamma_kMpl005_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_5750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9d90cf55e6836118033429169982dcbf/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211846/0000/RSGravitonToGammaGamma_kMpl005_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211846/0000/RSGravitonToGammaGamma_kMpl005_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_5875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2cf80077ebc924cd466cb78aae4386a4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211846/0000/RSGravitonToGammaGamma_kMpl005_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211846/0000/RSGravitonToGammaGamma_kMpl005_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_6000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e9aa28831a876cc6a3e3ddafdc669487/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211856/0000/RSGravitonToGammaGamma_kMpl005_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211856/0000/RSGravitonToGammaGamma_kMpl005_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_6125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-64eb40fbd28be58cebad37d18af7ccf6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211856/0000/RSGravitonToGammaGamma_kMpl005_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211856/0000/RSGravitonToGammaGamma_kMpl005_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_6250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c5c78f5c29d6aeb92a3716d17e862784/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211856/0000/RSGravitonToGammaGamma_kMpl005_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a055ddbad46aff82ce7d86b8e3d0a17a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211856/0000/RSGravitonToGammaGamma_kMpl005_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211856/0000/RSGravitonToGammaGamma_kMpl005_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_6375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7eee3219e7e2dbd7253d99da8642921a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211857/0000/RSGravitonToGammaGamma_kMpl005_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211857/0000/RSGravitonToGammaGamma_kMpl005_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_6500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f1469e2b9d0a6d9be778a4e1fd086389/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211900/0000/RSGravitonToGammaGamma_kMpl005_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211900/0000/RSGravitonToGammaGamma_kMpl005_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_6625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-899fee7f953613a5766e9120cbbb288e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211900/0000/RSGravitonToGammaGamma_kMpl005_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211900/0000/RSGravitonToGammaGamma_kMpl005_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_6750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-911a4db2581f5147e4b23799c0db6e2a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211900/0000/RSGravitonToGammaGamma_kMpl005_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211900/0000/RSGravitonToGammaGamma_kMpl005_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_6875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8186e6540346691cfea00f8aa7f04768/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211914/0000/RSGravitonToGammaGamma_kMpl005_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211914/0000/RSGravitonToGammaGamma_kMpl005_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl005_M_7000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8286795bb00144a63a3c7692da7d95d5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211909/0000/RSGravitonToGammaGamma_kMpl005_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211909/0000/RSGravitonToGammaGamma_kMpl005_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-eb5c7afb1afda416c164653eb4ef9da9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211915/0000/RSGravitonToGammaGamma_kMpl005_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211915/0000/RSGravitonToGammaGamma_kMpl005_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl005_M_875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1561d390f1d6c2a9ed45a7caf51fb925/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl005_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211915/0000/RSGravitonToGammaGamma_kMpl005_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_1000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b3390c7d2b21bd8c1bd17f60e4af3143/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211915/0000/RSGravitonToGammaGamma_kMpl007_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211915/0000/RSGravitonToGammaGamma_kMpl007_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_1125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ad3a7d289cec027d81ebec6499356e0c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211918/0000/RSGravitonToGammaGamma_kMpl007_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_1250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b877c5b65ae1d464a38b127e32d48a12/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211918/0000/RSGravitonToGammaGamma_kMpl007_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211918/0000/RSGravitonToGammaGamma_kMpl007_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_1375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-dfdb31424fb0b5a7785e545edf408425/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211918/0000/RSGravitonToGammaGamma_kMpl007_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211918/0000/RSGravitonToGammaGamma_kMpl007_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_1500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7b7d6a5a6101ca863d9f8336a96dccd5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211926/0000/RSGravitonToGammaGamma_kMpl007_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211926/0000/RSGravitonToGammaGamma_kMpl007_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_1625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-86367e1501167a478c9c4278ba9807fa/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211929/0000/RSGravitonToGammaGamma_kMpl007_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211929/0000/RSGravitonToGammaGamma_kMpl007_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_1750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3eb1223f23a083c55920b2d5d07f22be/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211929/0000/RSGravitonToGammaGamma_kMpl007_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211929/0000/RSGravitonToGammaGamma_kMpl007_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_1875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b953598af4bde8c34e8fd96050cab3c0/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211931/0000/RSGravitonToGammaGamma_kMpl007_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_2125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cfb80c175952f782f1e6c9bbe7c79cda/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211933/0000/RSGravitonToGammaGamma_kMpl007_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211933/0000/RSGravitonToGammaGamma_kMpl007_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_2250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a4b63b7fa208df52c21981416ddd5d0d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211933/0000/RSGravitonToGammaGamma_kMpl007_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211933/0000/RSGravitonToGammaGamma_kMpl007_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_2375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c42b38453e46c31fd44dcb1c1233d10c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211933/0000/RSGravitonToGammaGamma_kMpl007_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211933/0000/RSGravitonToGammaGamma_kMpl007_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_2500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-58e88d99d6f563bee8768d9479407480/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211942/0000/RSGravitonToGammaGamma_kMpl007_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211942/0000/RSGravitonToGammaGamma_kMpl007_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_2625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-15e15f2242d84b250e50a5b48e2afe10/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211942/0000/RSGravitonToGammaGamma_kMpl007_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211942/0000/RSGravitonToGammaGamma_kMpl007_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_2750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8c28d9091e578e725ba61bc4af3f8bc8/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211942/0000/RSGravitonToGammaGamma_kMpl007_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211942/0000/RSGravitonToGammaGamma_kMpl007_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_2875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-66f50c7d612873add15adc4828847f1b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211945/0000/RSGravitonToGammaGamma_kMpl007_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211945/0000/RSGravitonToGammaGamma_kMpl007_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_3000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8a58f284929e25810b03c45279b08610/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211945/0000/RSGravitonToGammaGamma_kMpl007_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_3500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-39074b1840ad4d8cba9baa9f1d16778f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211946/0000/RSGravitonToGammaGamma_kMpl007_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211946/0000/RSGravitonToGammaGamma_kMpl007_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_3625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a1586bde94020785225393055d3c64c2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211950/0000/RSGravitonToGammaGamma_kMpl007_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211950/0000/RSGravitonToGammaGamma_kMpl007_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_3750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9f9775aad8777f8c9fa11f7a4deb58c7/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211950/0000/RSGravitonToGammaGamma_kMpl007_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211950/0000/RSGravitonToGammaGamma_kMpl007_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_3875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5675bcca0855d4ccc3fd9589123b1cab/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211956/0000/RSGravitonToGammaGamma_kMpl007_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211956/0000/RSGravitonToGammaGamma_kMpl007_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_4000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d081dec2969cadbec701fabf341e46a6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211956/0000/RSGravitonToGammaGamma_kMpl007_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211956/0000/RSGravitonToGammaGamma_kMpl007_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_4125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-131ea1d456baee0f7b88876e219a3dd6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211955/0000/RSGravitonToGammaGamma_kMpl007_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_211955/0000/RSGravitonToGammaGamma_kMpl007_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_4250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-786c0e6786b7ba51e2dd88655189ea4d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212001/0000/RSGravitonToGammaGamma_kMpl007_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212001/0000/RSGravitonToGammaGamma_kMpl007_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_4375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9533023d6327feac05cca480b21d8b78/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212001/0000/RSGravitonToGammaGamma_kMpl007_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212001/0000/RSGravitonToGammaGamma_kMpl007_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_4500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-465dd8aad85f57f1aa6ef9b5248345a3/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212001/0000/RSGravitonToGammaGamma_kMpl007_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212001/0000/RSGravitonToGammaGamma_kMpl007_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_4625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fc6820d34bf901f2d9b90f4129a66fb1/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212004/0000/RSGravitonToGammaGamma_kMpl007_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212004/0000/RSGravitonToGammaGamma_kMpl007_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_4750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f0780a67d6208f91d50bf479f0742f99/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212003/0000/RSGravitonToGammaGamma_kMpl007_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212003/0000/RSGravitonToGammaGamma_kMpl007_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_4875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-abab82fe85903ddff9875013e099ee67/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212008/0000/RSGravitonToGammaGamma_kMpl007_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212008/0000/RSGravitonToGammaGamma_kMpl007_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d7dcbc9b73f57cd588033ed977d4d9c9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212010/0000/RSGravitonToGammaGamma_kMpl007_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212010/0000/RSGravitonToGammaGamma_kMpl007_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_5125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f37f0ec357b0e143ec783381c5a7ce81/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212018/0000/RSGravitonToGammaGamma_kMpl007_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212018/0000/RSGravitonToGammaGamma_kMpl007_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_5250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cea8458a6316f6b9c31b824850c92dbe/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212018/0000/RSGravitonToGammaGamma_kMpl007_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212018/0000/RSGravitonToGammaGamma_kMpl007_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_5375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8d202f2118385904fcdf1bd377e737f8/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212018/0000/RSGravitonToGammaGamma_kMpl007_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212018/0000/RSGravitonToGammaGamma_kMpl007_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_5500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e71245258e53de011f02f14ab1172688/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212019/0000/RSGravitonToGammaGamma_kMpl007_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212019/0000/RSGravitonToGammaGamma_kMpl007_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_5625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-eacbe9c7fdec6d6c92409d11a761cc20/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212019/0000/RSGravitonToGammaGamma_kMpl007_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212019/0000/RSGravitonToGammaGamma_kMpl007_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_5750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5131bb898650ac780cb0072e4d7c74c7/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212020/0000/RSGravitonToGammaGamma_kMpl007_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212020/0000/RSGravitonToGammaGamma_kMpl007_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_5875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-de45f86b6871a57aaffa5bc196b1d695/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212030/0000/RSGravitonToGammaGamma_kMpl007_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212030/0000/RSGravitonToGammaGamma_kMpl007_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_6000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9cc5565df5d8c1b4fa3afe031871f441/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212023/0000/RSGravitonToGammaGamma_kMpl007_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212023/0000/RSGravitonToGammaGamma_kMpl007_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_6125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9fb5a7c3def6e2aa9f20b8301e903481/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_6250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-36d2df88f271be56d9b2b38cb962e591/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-66b4e667a0ec8e516908545e096e811c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_6375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fc5e2c98ef125d84cb527a1d8d128ea6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_6500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2f09ea283acf04b16de17f74159ddb75/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_6625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-425f5008b325fb23cafa4385bf8e80d2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_6750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-085c50f4fbe5fb78f51083c12dd4db86/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212425/0000/RSGravitonToGammaGamma_kMpl007_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl007_M_6875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-530d2239fba104441982a504e06997fb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212426/0000/RSGravitonToGammaGamma_kMpl007_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212426/0000/RSGravitonToGammaGamma_kMpl007_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_7000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f0211ef3f377b62b181b793addce5d02/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212449/0000/RSGravitonToGammaGamma_kMpl007_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212449/0000/RSGravitonToGammaGamma_kMpl007_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-75ad0a9e6346de0fd25c2fb4704294ef/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212452/0000/RSGravitonToGammaGamma_kMpl007_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212452/0000/RSGravitonToGammaGamma_kMpl007_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl007_M_875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a0245bf6d55a5721afb6f4da940c4275/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212450/0000/RSGravitonToGammaGamma_kMpl007_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl007_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212450/0000/RSGravitonToGammaGamma_kMpl007_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_1000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cfba7ad93745e699d0de0cdff575b07a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212452/0000/RSGravitonToGammaGamma_kMpl015_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212452/0000/RSGravitonToGammaGamma_kMpl015_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_1125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-94f29c283d93cbb318b4c86e53d6f07a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212449/0000/RSGravitonToGammaGamma_kMpl015_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212449/0000/RSGravitonToGammaGamma_kMpl015_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_1250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8d65dd9d4c6d86e9017711f565f08fa2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212450/0000/RSGravitonToGammaGamma_kMpl015_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212450/0000/RSGravitonToGammaGamma_kMpl015_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_1375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2515fa7ba8edf14d01b45a40e86b0b14/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212450/0000/RSGravitonToGammaGamma_kMpl015_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212450/0000/RSGravitonToGammaGamma_kMpl015_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_1500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5ad3ef78f717ba589c3df5b3ecd83c8e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212452/0000/RSGravitonToGammaGamma_kMpl015_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212452/0000/RSGravitonToGammaGamma_kMpl015_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_1625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-500f25c9db48e9c9a96c4be5d622322a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212505/0000/RSGravitonToGammaGamma_kMpl015_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212505/0000/RSGravitonToGammaGamma_kMpl015_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_1750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fe770cd53351ac68e8ded81317092755/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212505/0000/RSGravitonToGammaGamma_kMpl015_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212505/0000/RSGravitonToGammaGamma_kMpl015_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_1875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-46649ff04c0db20eb4fcfff0f02450c4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212506/0000/RSGravitonToGammaGamma_kMpl015_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212506/0000/RSGravitonToGammaGamma_kMpl015_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl015_M_2000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-624cdc4a3d8f0928768d34bab5da3611/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212506/0000/RSGravitonToGammaGamma_kMpl015_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212506/0000/RSGravitonToGammaGamma_kMpl015_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_2125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-71be715b3cff4e98e1993ac2c5fbd3c4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212506/0000/RSGravitonToGammaGamma_kMpl015_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212506/0000/RSGravitonToGammaGamma_kMpl015_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_2250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b3ae47b2b865fb970a874896fc59d538/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212509/0000/RSGravitonToGammaGamma_kMpl015_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212509/0000/RSGravitonToGammaGamma_kMpl015_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_2375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e3c8188ac5206703439bd65c6491a336/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212509/0000/RSGravitonToGammaGamma_kMpl015_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212509/0000/RSGravitonToGammaGamma_kMpl015_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_2500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-59f2fde2b16b1a0e03534cd83003c716/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212510/0000/RSGravitonToGammaGamma_kMpl015_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212510/0000/RSGravitonToGammaGamma_kMpl015_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_2625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f95f77dd0a86f8d50bb8807e3a8daa38/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212521/0000/RSGravitonToGammaGamma_kMpl015_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212521/0000/RSGravitonToGammaGamma_kMpl015_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_2750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-438053ce30e762a50a8be3ff40e37f66/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212525/0000/RSGravitonToGammaGamma_kMpl015_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212525/0000/RSGravitonToGammaGamma_kMpl015_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_2875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6d60d7d541d0e8626537d999d744c373/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212526/0000/RSGravitonToGammaGamma_kMpl015_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_3000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-4207432f8f36df50614b54f998ab5ebf/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212525/0000/RSGravitonToGammaGamma_kMpl015_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212525/0000/RSGravitonToGammaGamma_kMpl015_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl015_M_3500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-87e73d1b30e9b68b3a0e7f7d08af8662/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212526/0000/RSGravitonToGammaGamma_kMpl015_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212526/0000/RSGravitonToGammaGamma_kMpl015_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_3625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fb54512c9d4c193847a3e9a4541a770a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212526/0000/RSGravitonToGammaGamma_kMpl015_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212526/0000/RSGravitonToGammaGamma_kMpl015_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_3750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e572fc62930d5e306e2ddf2da1da817a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212528/0000/RSGravitonToGammaGamma_kMpl015_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212528/0000/RSGravitonToGammaGamma_kMpl015_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_3875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e4870e1c4e96e02299e7536d1d09cffb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212528/0000/RSGravitonToGammaGamma_kMpl015_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212528/0000/RSGravitonToGammaGamma_kMpl015_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_4000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c51c1554c1bed5f14dc6db6e694662e7/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212536/0000/RSGravitonToGammaGamma_kMpl015_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212536/0000/RSGravitonToGammaGamma_kMpl015_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_4125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-82f6fba7fc36c8f7c20aa8da2d2cc7db/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212541/0000/RSGravitonToGammaGamma_kMpl015_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212541/0000/RSGravitonToGammaGamma_kMpl015_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl015_M_4250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a0666ae66b5d6be47dadd3d4d9497619/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212541/0000/RSGravitonToGammaGamma_kMpl015_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212541/0000/RSGravitonToGammaGamma_kMpl015_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_4500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0ddac4a67e7f2f8c683047bde87c3f77/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212546/0000/RSGravitonToGammaGamma_kMpl015_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212546/0000/RSGravitonToGammaGamma_kMpl015_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_4625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1ad8c7cab160b696527b2dfc480d77ca/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212546/0000/RSGravitonToGammaGamma_kMpl015_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212546/0000/RSGravitonToGammaGamma_kMpl015_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_4750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3672206b32f8af051877a0f944cd1633/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212546/0000/RSGravitonToGammaGamma_kMpl015_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212546/0000/RSGravitonToGammaGamma_kMpl015_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_4875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-bd4abd61e54a10a56e9b5ec13873c057/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212544/0000/RSGravitonToGammaGamma_kMpl015_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_5000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-40d4a12f5289457c5f431603ead2e0d4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212549/0000/RSGravitonToGammaGamma_kMpl015_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212549/0000/RSGravitonToGammaGamma_kMpl015_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-4c18cebd3c9a2a365de80144a66964f2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212554/0000/RSGravitonToGammaGamma_kMpl015_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212554/0000/RSGravitonToGammaGamma_kMpl015_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl015_M_5125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5335d4dd9da86157dd5ae0ac01061214/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212555/0000/RSGravitonToGammaGamma_kMpl015_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212555/0000/RSGravitonToGammaGamma_kMpl015_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_5250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6c69e12ba3fed0b5bee76db1ab1cb3a8/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212557/0000/RSGravitonToGammaGamma_kMpl015_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_5375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5cf7f25fb6554d1fd851a00a8379f52b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212558/0000/RSGravitonToGammaGamma_kMpl015_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212558/0000/RSGravitonToGammaGamma_kMpl015_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_5500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-36ba7b3845eb31b5078f79edb4d40d18/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212603/0000/RSGravitonToGammaGamma_kMpl015_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212603/0000/RSGravitonToGammaGamma_kMpl015_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_5625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c8c9042b57e05dada71131d71612d5bb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212602/0000/RSGravitonToGammaGamma_kMpl015_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212602/0000/RSGravitonToGammaGamma_kMpl015_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_5750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6138c17cc2bf41ae1d1d54c8ab88c438/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212603/0000/RSGravitonToGammaGamma_kMpl015_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212603/0000/RSGravitonToGammaGamma_kMpl015_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_5875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-584e14866eb87fcaeb5a8dcdc28ea0cb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212603/0000/RSGravitonToGammaGamma_kMpl015_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212603/0000/RSGravitonToGammaGamma_kMpl015_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_6000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-94bc555274e90f7b6b3e6173b7136d1c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212611/0000/RSGravitonToGammaGamma_kMpl015_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212611/0000/RSGravitonToGammaGamma_kMpl015_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_6125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3fd704bcda8a46e577c9704d7eba2bd1/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212611/0000/RSGravitonToGammaGamma_kMpl015_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212611/0000/RSGravitonToGammaGamma_kMpl015_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_6250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-da8bff30530c2397bce8c0110745bec5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212612/0000/RSGravitonToGammaGamma_kMpl015_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212612/0000/RSGravitonToGammaGamma_kMpl015_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a236cecd05eba206478ba86310665451/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212612/0000/RSGravitonToGammaGamma_kMpl015_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212612/0000/RSGravitonToGammaGamma_kMpl015_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_6375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f4f571b4f6675ebc303f0a43a2f3b8e8/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212616/0000/RSGravitonToGammaGamma_kMpl015_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212616/0000/RSGravitonToGammaGamma_kMpl015_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_6500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7f27d5a473ff2c93cd138fc2b314b61f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212619/0000/RSGravitonToGammaGamma_kMpl015_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212619/0000/RSGravitonToGammaGamma_kMpl015_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_6625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-24f6fefef528ee9e6c034bb32013ab0e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212619/0000/RSGravitonToGammaGamma_kMpl015_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212619/0000/RSGravitonToGammaGamma_kMpl015_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_6750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-07b7d3f5b385c6f80dd1d15bcd0f6be8/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212619/0000/RSGravitonToGammaGamma_kMpl015_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212619/0000/RSGravitonToGammaGamma_kMpl015_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl015_M_6875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fcea196119068f8efa1d552d2649bcfa/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212626/0000/RSGravitonToGammaGamma_kMpl015_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212626/0000/RSGravitonToGammaGamma_kMpl015_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_7000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9124328e9744863a86ef0e6b5d1778f0/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212626/0000/RSGravitonToGammaGamma_kMpl015_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212626/0000/RSGravitonToGammaGamma_kMpl015_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl015_M_750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-434ca4c907cb38a7cd659b0ddccf6a58/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212627/0000/RSGravitonToGammaGamma_kMpl015_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212627/0000/RSGravitonToGammaGamma_kMpl015_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl015_M_875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-90f6d976fcb8afbfbeac3e4cfe4f79d6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212627/0000/RSGravitonToGammaGamma_kMpl015_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl015_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212627/0000/RSGravitonToGammaGamma_kMpl015_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_1000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c5b2e7cdf84d43f51951e9c76bb099ff/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212628/0000/RSGravitonToGammaGamma_kMpl01_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_1125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a0a063b7ffa54d17b0fbe0c034f82f4f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212633/0000/RSGravitonToGammaGamma_kMpl01_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212633/0000/RSGravitonToGammaGamma_kMpl01_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_1250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-925f3834c5414fb05c2dbf1181aaee51/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212633/0000/RSGravitonToGammaGamma_kMpl01_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212633/0000/RSGravitonToGammaGamma_kMpl01_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_1375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-06c925590f2eec6d5f9c2921542639c4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212633/0000/RSGravitonToGammaGamma_kMpl01_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212633/0000/RSGravitonToGammaGamma_kMpl01_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_1500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d5dd21544c394745112f18788620a56e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212647/0000/RSGravitonToGammaGamma_kMpl01_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl01_M_1625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3365e7719157f805189a54a53689503a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212646/0000/RSGravitonToGammaGamma_kMpl01_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_1750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1ae9ee065c836d4b14ae1ac2f8634b5f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212646/0000/RSGravitonToGammaGamma_kMpl01_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212646/0000/RSGravitonToGammaGamma_kMpl01_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_2000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f941531902257cff9ee48133c9d92616/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212647/0000/RSGravitonToGammaGamma_kMpl01_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212647/0000/RSGravitonToGammaGamma_kMpl01_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_2125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f607c164599240cd2916cacf94413af5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212649/0000/RSGravitonToGammaGamma_kMpl01_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212649/0000/RSGravitonToGammaGamma_kMpl01_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_2250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9c9e1b07efd4a28f8363771ce8a286cf/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212649/0000/RSGravitonToGammaGamma_kMpl01_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212649/0000/RSGravitonToGammaGamma_kMpl01_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_2375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-147eb3589cb7a22a0ce254ee6331b094/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212649/0000/RSGravitonToGammaGamma_kMpl01_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212649/0000/RSGravitonToGammaGamma_kMpl01_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_2500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2c2b57cfcc3eda21f9a1dc8a3370d7cc/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212710/0000/RSGravitonToGammaGamma_kMpl01_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212710/0000/RSGravitonToGammaGamma_kMpl01_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl01_M_2625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2cd238737e272d20f985702a5f96311a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212710/0000/RSGravitonToGammaGamma_kMpl01_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212710/0000/RSGravitonToGammaGamma_kMpl01_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_2750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-aaa5fe4c3eb271f80dc797b188b15dcc/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212713/0000/RSGravitonToGammaGamma_kMpl01_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212713/0000/RSGravitonToGammaGamma_kMpl01_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl01_M_2875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d25fbf15a20ae7494d26857564cee469/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212710/0000/RSGravitonToGammaGamma_kMpl01_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_3000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-128a22ee025ee2a834b8e96ab81010df/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212704/0000/RSGravitonToGammaGamma_kMpl01_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212704/0000/RSGravitonToGammaGamma_kMpl01_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_3500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d6adbe2fd4bb40f5d0ebb3340b6e1068/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212708/0000/RSGravitonToGammaGamma_kMpl01_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212708/0000/RSGravitonToGammaGamma_kMpl01_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_3625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f0e72e434cfc9f83cdd6a94550f28a8b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212713/0000/RSGravitonToGammaGamma_kMpl01_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212713/0000/RSGravitonToGammaGamma_kMpl01_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_3750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8f16c6ebddb2592fe0d101ef234b73be/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212713/0000/RSGravitonToGammaGamma_kMpl01_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212713/0000/RSGravitonToGammaGamma_kMpl01_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_3875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-774a74d33a7626de9e0cf771234b3c34/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212718/0000/RSGravitonToGammaGamma_kMpl01_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212718/0000/RSGravitonToGammaGamma_kMpl01_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_4000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5d3284df802aad2169fa5301445cd686/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212724/0000/RSGravitonToGammaGamma_kMpl01_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212724/0000/RSGravitonToGammaGamma_kMpl01_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_4125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1f45adeef1190f836d0d65b4d36d3a53/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212729/0000/RSGravitonToGammaGamma_kMpl01_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212729/0000/RSGravitonToGammaGamma_kMpl01_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_4250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7e90da2dfbf0c041639c7050ccc02d99/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212729/0000/RSGravitonToGammaGamma_kMpl01_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212729/0000/RSGravitonToGammaGamma_kMpl01_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_4375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-206663c4de1856d1dfe9d1021f006b16/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212738/0000/RSGravitonToGammaGamma_kMpl01_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212738/0000/RSGravitonToGammaGamma_kMpl01_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_4500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3e139bf79e8f3e534a07ebeb0f6dbeca/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212738/0000/RSGravitonToGammaGamma_kMpl01_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212738/0000/RSGravitonToGammaGamma_kMpl01_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_4625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-300104cef5d953539b00f9c50874df42/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212739/0000/RSGravitonToGammaGamma_kMpl01_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212739/0000/RSGravitonToGammaGamma_kMpl01_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_4750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0c068a781f830c6de0a6b12e4ab7203b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212735/0000/RSGravitonToGammaGamma_kMpl01_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212735/0000/RSGravitonToGammaGamma_kMpl01_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_4875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-77d8971501dcd55a13764afc9d6915df/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212749/0000/RSGravitonToGammaGamma_kMpl01_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212749/0000/RSGravitonToGammaGamma_kMpl01_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl01_M_5000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c742df6971a5899e0f624660480c9376/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212749/0000/RSGravitonToGammaGamma_kMpl01_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212749/0000/RSGravitonToGammaGamma_kMpl01_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ab0e840faa57c3835588affe6670a400/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212750/0000/RSGravitonToGammaGamma_kMpl01_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212750/0000/RSGravitonToGammaGamma_kMpl01_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_5125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a254e883b99ac474b904f4df488ece4d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212745/0000/RSGravitonToGammaGamma_kMpl01_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212745/0000/RSGravitonToGammaGamma_kMpl01_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_5250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1b399afe6ac4884f999dd2cfcdec9ad5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212750/0000/RSGravitonToGammaGamma_kMpl01_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212750/0000/RSGravitonToGammaGamma_kMpl01_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_5375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b43de5f1e1f7e89e97c4d097c3a06cf3/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212757/0000/RSGravitonToGammaGamma_kMpl01_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212757/0000/RSGravitonToGammaGamma_kMpl01_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_5625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f4095ec8fa18fb945bb5aa0a1cc19d17/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212757/0000/RSGravitonToGammaGamma_kMpl01_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212757/0000/RSGravitonToGammaGamma_kMpl01_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_5750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c4ecd23ad7374428459f4785b07a482d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212759/0000/RSGravitonToGammaGamma_kMpl01_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212759/0000/RSGravitonToGammaGamma_kMpl01_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_5875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b05ff119b35c575464ea5dc900746ff4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212805/0000/RSGravitonToGammaGamma_kMpl01_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212805/0000/RSGravitonToGammaGamma_kMpl01_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_6000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b56339c95091f84f7873dc2ea71d16f8/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212809/0000/RSGravitonToGammaGamma_kMpl01_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212809/0000/RSGravitonToGammaGamma_kMpl01_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_6125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-902d5371f56d3c4f1970e996f3b31234/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212809/0000/RSGravitonToGammaGamma_kMpl01_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212809/0000/RSGravitonToGammaGamma_kMpl01_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_6250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d4e5a559d536b008d9b7f1ab8d9d74a9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212808/0000/RSGravitonToGammaGamma_kMpl01_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212808/0000/RSGravitonToGammaGamma_kMpl01_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e5c6f70b7e3416bf1ea759b60e41a6d1/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212814/0000/RSGravitonToGammaGamma_kMpl01_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl01_M_6375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3aef762a698e8072d8a038f2bad5b0a1/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212814/0000/RSGravitonToGammaGamma_kMpl01_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212814/0000/RSGravitonToGammaGamma_kMpl01_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_6500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1dddf355eddc2cb8f88c08fc0d9a6acb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212814/0000/RSGravitonToGammaGamma_kMpl01_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212814/0000/RSGravitonToGammaGamma_kMpl01_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_6625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-93824648f02cc231ceb772d144b9f174/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212814/0000/RSGravitonToGammaGamma_kMpl01_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212814/0000/RSGravitonToGammaGamma_kMpl01_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_6750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6b5352d944644c56671195791f6267b2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212817/0000/RSGravitonToGammaGamma_kMpl01_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212817/0000/RSGravitonToGammaGamma_kMpl01_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_6875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-40a18ee47cce47bacb5974644ee47b92/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212824/0000/RSGravitonToGammaGamma_kMpl01_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212824/0000/RSGravitonToGammaGamma_kMpl01_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_7000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5b2543079e41c763d47a500262b710aa/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212824/0000/RSGravitonToGammaGamma_kMpl01_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212824/0000/RSGravitonToGammaGamma_kMpl01_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cc129aeed024efdad719c2c007517cb3/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212824/0000/RSGravitonToGammaGamma_kMpl01_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212824/0000/RSGravitonToGammaGamma_kMpl01_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl01_M_875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5fbbc567419a0c9cf022b6fa1ebcb1eb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212829/0000/RSGravitonToGammaGamma_kMpl01_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl01_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212829/0000/RSGravitonToGammaGamma_kMpl01_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_1000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0b1345d2d2182c5b07e352d8d7ddbb9b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212827/0000/RSGravitonToGammaGamma_kMpl025_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212827/0000/RSGravitonToGammaGamma_kMpl025_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_1125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-bf776e4d97bd1a453023a64cb24a1e3f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212830/0000/RSGravitonToGammaGamma_kMpl025_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212830/0000/RSGravitonToGammaGamma_kMpl025_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_1250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7598a11616e1894b107690d433d127cc/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212830/0000/RSGravitonToGammaGamma_kMpl025_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212830/0000/RSGravitonToGammaGamma_kMpl025_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_1375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b0066429b394d916801e71a1d6325fe9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212831/0000/RSGravitonToGammaGamma_kMpl025_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212831/0000/RSGravitonToGammaGamma_kMpl025_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_1500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-900ceaa58321f42615bc4d381bf2be0e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212841/0000/RSGravitonToGammaGamma_kMpl025_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212841/0000/RSGravitonToGammaGamma_kMpl025_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_1625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6fa2259bd9c70c9fef1b74240c8ed50a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212841/0000/RSGravitonToGammaGamma_kMpl025_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212841/0000/RSGravitonToGammaGamma_kMpl025_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_1750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5db9d4542242c7072a8eb50d184f15f9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212841/0000/RSGravitonToGammaGamma_kMpl025_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212841/0000/RSGravitonToGammaGamma_kMpl025_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_1875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-33c610727d8f21d48184a0bab004e4dc/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212841/0000/RSGravitonToGammaGamma_kMpl025_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_2000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fc80ee68fab0002b4b057c857db4f251/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212846/0000/RSGravitonToGammaGamma_kMpl025_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212846/0000/RSGravitonToGammaGamma_kMpl025_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_2125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2c79ce3991f3194f03c910fe4415192c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212846/0000/RSGravitonToGammaGamma_kMpl025_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212846/0000/RSGravitonToGammaGamma_kMpl025_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_2250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b2bcfb9ecd7499a83af9cac99abae127/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212846/0000/RSGravitonToGammaGamma_kMpl025_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212846/0000/RSGravitonToGammaGamma_kMpl025_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_2375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-37c55554ffabe80b34d0756468d7789a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212844/0000/RSGravitonToGammaGamma_kMpl025_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212844/0000/RSGravitonToGammaGamma_kMpl025_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_2500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9a406c4dbc39a2c80a521ef7b3d515a8/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212900/0000/RSGravitonToGammaGamma_kMpl025_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212900/0000/RSGravitonToGammaGamma_kMpl025_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_2625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-655c262ccf6fd7bfbebb3d02f90ca8ed/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212902/0000/RSGravitonToGammaGamma_kMpl025_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212902/0000/RSGravitonToGammaGamma_kMpl025_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_2750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-05e77d34ca32c2c650a4f2fccd2f5735/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212903/0000/RSGravitonToGammaGamma_kMpl025_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212903/0000/RSGravitonToGammaGamma_kMpl025_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_2875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6b8f25095658afa88fa1b7f5b034a6cf/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212903/0000/RSGravitonToGammaGamma_kMpl025_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212903/0000/RSGravitonToGammaGamma_kMpl025_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_3000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-36896699b316b5a40f1833ae3712eefb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212903/0000/RSGravitonToGammaGamma_kMpl025_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_3500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-39f2439d60759d1b697521abd61116b4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212904/0000/RSGravitonToGammaGamma_kMpl025_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212904/0000/RSGravitonToGammaGamma_kMpl025_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl025_M_3625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-44d402e03ee278af7450b10b440e2a47/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212903/0000/RSGravitonToGammaGamma_kMpl025_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212903/0000/RSGravitonToGammaGamma_kMpl025_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_3750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-85681475cff6cf15c9e1c3bf743bfbb4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212904/0000/RSGravitonToGammaGamma_kMpl025_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212904/0000/RSGravitonToGammaGamma_kMpl025_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_3875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-65bb4feffce3aa8992bce32e7813043f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212926/0000/RSGravitonToGammaGamma_kMpl025_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212926/0000/RSGravitonToGammaGamma_kMpl025_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_4000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9706f929810d052b5f0681d02ea9ca58/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212925/0000/RSGravitonToGammaGamma_kMpl025_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212925/0000/RSGravitonToGammaGamma_kMpl025_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_4125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2feb93f07a736983cb7f2ad650f6c19d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212926/0000/RSGravitonToGammaGamma_kMpl025_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212926/0000/RSGravitonToGammaGamma_kMpl025_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_4250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-712e0a47e699ea82f535ef8a3ae09d94/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212926/0000/RSGravitonToGammaGamma_kMpl025_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212926/0000/RSGravitonToGammaGamma_kMpl025_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_4375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6134469dd4be2ccb8ed08ea069131e71/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212929/0000/RSGravitonToGammaGamma_kMpl025_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212929/0000/RSGravitonToGammaGamma_kMpl025_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl025_M_4500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ea80b0f43ff13539cb40dcea74cdab74/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212929/0000/RSGravitonToGammaGamma_kMpl025_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212929/0000/RSGravitonToGammaGamma_kMpl025_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_4625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b247642f34d2390a2a580d49d14766c6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212926/0000/RSGravitonToGammaGamma_kMpl025_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212926/0000/RSGravitonToGammaGamma_kMpl025_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl025_M_4750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fa4081b6d7183fed3bfff56ab48c17ce/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212929/0000/RSGravitonToGammaGamma_kMpl025_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212929/0000/RSGravitonToGammaGamma_kMpl025_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_4875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cc3fba47f3ea685923733dc83c1fc1a2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212942/0000/RSGravitonToGammaGamma_kMpl025_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212942/0000/RSGravitonToGammaGamma_kMpl025_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_5000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-dea19f6ce239fab500ae4627277a2eeb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212949/0000/RSGravitonToGammaGamma_kMpl025_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212949/0000/RSGravitonToGammaGamma_kMpl025_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl025_M_500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2b3de900d1d152ac74e31e62dde1a757/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212949/0000/RSGravitonToGammaGamma_kMpl025_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212949/0000/RSGravitonToGammaGamma_kMpl025_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_5125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f9ed7d307845c8b761ba80668e6713d7/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212950/0000/RSGravitonToGammaGamma_kMpl025_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212950/0000/RSGravitonToGammaGamma_kMpl025_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_5250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-051c79da7d422adc64d9d52a1af664e0/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212950/0000/RSGravitonToGammaGamma_kMpl025_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212950/0000/RSGravitonToGammaGamma_kMpl025_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_5375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2d02fe4762eff89bee7ab2c1f2db2cda/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212952/0000/RSGravitonToGammaGamma_kMpl025_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212952/0000/RSGravitonToGammaGamma_kMpl025_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_5500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-bd72d47f96bbff26f59ca05c26f87239/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212950/0000/RSGravitonToGammaGamma_kMpl025_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212950/0000/RSGravitonToGammaGamma_kMpl025_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl025_M_5625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e5d5177596738a5196920525e6d6f894/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212952/0000/RSGravitonToGammaGamma_kMpl025_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212952/0000/RSGravitonToGammaGamma_kMpl025_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_5750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-42cf653d91b6b229327c31ad9553a379/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212959/0000/RSGravitonToGammaGamma_kMpl025_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_212959/0000/RSGravitonToGammaGamma_kMpl025_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_5875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-81d69b9661e87af5e773db7e75509a3b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213009/0000/RSGravitonToGammaGamma_kMpl025_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213009/0000/RSGravitonToGammaGamma_kMpl025_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_6000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-88b8c9290863f8d914c0bffc97dc210f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213008/0000/RSGravitonToGammaGamma_kMpl025_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213008/0000/RSGravitonToGammaGamma_kMpl025_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_6125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e05237ba09c487340010cf9e423133a2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213009/0000/RSGravitonToGammaGamma_kMpl025_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213009/0000/RSGravitonToGammaGamma_kMpl025_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_6250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2db1f9fa855901f999b943eed12ba34d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213012/0000/RSGravitonToGammaGamma_kMpl025_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213012/0000/RSGravitonToGammaGamma_kMpl025_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9b3e2db78b02824b7355cf878b1416a4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213012/0000/RSGravitonToGammaGamma_kMpl025_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213012/0000/RSGravitonToGammaGamma_kMpl025_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_6375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6161243961ecdc537f2c2d33b784e0b6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213013/0000/RSGravitonToGammaGamma_kMpl025_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213013/0000/RSGravitonToGammaGamma_kMpl025_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_6500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6c14b6b76857aa757fbf9455739127e5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213012/0000/RSGravitonToGammaGamma_kMpl025_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213012/0000/RSGravitonToGammaGamma_kMpl025_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_6625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-245eb7433d040e769881a9a83282ba12/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213014/0000/RSGravitonToGammaGamma_kMpl025_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213014/0000/RSGravitonToGammaGamma_kMpl025_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_6750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-594bdcc779ebc4181c3a50ec58be8822/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213028/0000/RSGravitonToGammaGamma_kMpl025_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213028/0000/RSGravitonToGammaGamma_kMpl025_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_6875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e54518fd3da392850cd7fc021be8b2a1/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213035/0000/RSGravitonToGammaGamma_kMpl025_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213035/0000/RSGravitonToGammaGamma_kMpl025_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_7000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1cce78b480b27ad16c83ab2e65f3903a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213029/0000/RSGravitonToGammaGamma_kMpl025_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213029/0000/RSGravitonToGammaGamma_kMpl025_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6614a58650a9b1d2cb84b5d629961ab9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213035/0000/RSGravitonToGammaGamma_kMpl025_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213035/0000/RSGravitonToGammaGamma_kMpl025_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl025_M_875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-867d6b17ceb28045137d1c784d6fb7d5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213033/0000/RSGravitonToGammaGamma_kMpl025_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl025_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213033/0000/RSGravitonToGammaGamma_kMpl025_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl02_M_1000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7c7fd4151a9cef7b1325720498a16245/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213036/0000/RSGravitonToGammaGamma_kMpl02_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213036/0000/RSGravitonToGammaGamma_kMpl02_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_1125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-4226b9ff57cd6a67f2187eda8d192504/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213033/0000/RSGravitonToGammaGamma_kMpl02_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213033/0000/RSGravitonToGammaGamma_kMpl02_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_1250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9fedaddd41ca5f6678ce7ba33abf33d5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213033/0000/RSGravitonToGammaGamma_kMpl02_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213033/0000/RSGravitonToGammaGamma_kMpl02_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_1375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f7dff43fc423a834c8fad18616e1fc14/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213044/0000/RSGravitonToGammaGamma_kMpl02_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213044/0000/RSGravitonToGammaGamma_kMpl02_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_1625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9278f8cb6e4fe1cea8ba6a25a3d11c14/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213045/0000/RSGravitonToGammaGamma_kMpl02_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213045/0000/RSGravitonToGammaGamma_kMpl02_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl02_M_1750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-344f1b7a395ec5ff9cf60b69ee916c18/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213047/0000/RSGravitonToGammaGamma_kMpl02_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213047/0000/RSGravitonToGammaGamma_kMpl02_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_1875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-00836683af55b4520edbc73b50bfca61/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213046/0000/RSGravitonToGammaGamma_kMpl02_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213046/0000/RSGravitonToGammaGamma_kMpl02_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_2000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ae7417643a6528d15bc7afd4d7aa5593/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213057/0000/RSGravitonToGammaGamma_kMpl02_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213057/0000/RSGravitonToGammaGamma_kMpl02_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_2125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2ff383d85606413ba62b4aaa7e5464f4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213101/0000/RSGravitonToGammaGamma_kMpl02_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213101/0000/RSGravitonToGammaGamma_kMpl02_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_2250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e8464b5b48f238bf7dd2e6d7c958f83a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213050/0000/RSGravitonToGammaGamma_kMpl02_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213050/0000/RSGravitonToGammaGamma_kMpl02_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_2375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-22a8d629eaf7fdc7a0db253fa91ae7c4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213100/0000/RSGravitonToGammaGamma_kMpl02_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213100/0000/RSGravitonToGammaGamma_kMpl02_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_2500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-aab1eca110e36fd3ef511173ba0a8c0a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213100/0000/RSGravitonToGammaGamma_kMpl02_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213100/0000/RSGravitonToGammaGamma_kMpl02_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_2625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d4edcf691daaf447f25187949501d3cf/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213104/0000/RSGravitonToGammaGamma_kMpl02_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213104/0000/RSGravitonToGammaGamma_kMpl02_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_2750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e8a02dee3374b645f72ba090a8283c8e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213107/0000/RSGravitonToGammaGamma_kMpl02_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213107/0000/RSGravitonToGammaGamma_kMpl02_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_2875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9b7beac209c8174941825a2ee8b7373e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213107/0000/RSGravitonToGammaGamma_kMpl02_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213107/0000/RSGravitonToGammaGamma_kMpl02_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_3000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a724491e3f059e697ecdd035cc3a6952/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213109/0000/RSGravitonToGammaGamma_kMpl02_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213109/0000/RSGravitonToGammaGamma_kMpl02_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_3500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cbfc02bee4483f2852d664ebdacdd06a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213120/0000/RSGravitonToGammaGamma_kMpl02_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213120/0000/RSGravitonToGammaGamma_kMpl02_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_3750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c9ac6bc3ced48f3a93f968f4336b5837/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213120/0000/RSGravitonToGammaGamma_kMpl02_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213120/0000/RSGravitonToGammaGamma_kMpl02_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_3875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3ca22c8c40119b3d2dfdb489c6912584/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213121/0000/RSGravitonToGammaGamma_kMpl02_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213121/0000/RSGravitonToGammaGamma_kMpl02_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_4000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b2e223387d1c8e12a8e3a6dcca7a5aef/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213123/0000/RSGravitonToGammaGamma_kMpl02_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213123/0000/RSGravitonToGammaGamma_kMpl02_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_4125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-bb845ccf918763dbcc016fafd36f6d77/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213127/0000/RSGravitonToGammaGamma_kMpl02_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213127/0000/RSGravitonToGammaGamma_kMpl02_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_4250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e91073dcbd8e461edd96b4ecbe7cc8e1/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213127/0000/RSGravitonToGammaGamma_kMpl02_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213127/0000/RSGravitonToGammaGamma_kMpl02_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl02_M_4375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5404d9c55568ca1dad209f969960c2ed/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213127/0000/RSGravitonToGammaGamma_kMpl02_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213127/0000/RSGravitonToGammaGamma_kMpl02_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_4500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d3be7759d8fe0d010be4fd2da5607bb5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213146/0000/RSGravitonToGammaGamma_kMpl02_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_4625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-82b7588592a85018685f2356369524c3/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213150/0000/RSGravitonToGammaGamma_kMpl02_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213150/0000/RSGravitonToGammaGamma_kMpl02_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_4750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-28a560cb6ffc23b281eb284c62489d6c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213148/0000/RSGravitonToGammaGamma_kMpl02_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_4875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1d162c22e0f46ac59cf450b3b641e3be/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213148/0000/RSGravitonToGammaGamma_kMpl02_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213148/0000/RSGravitonToGammaGamma_kMpl02_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl02_M_5000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-71b08d93769b1f6e2dddb45c4975774e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213146/0000/RSGravitonToGammaGamma_kMpl02_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213146/0000/RSGravitonToGammaGamma_kMpl02_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5e1cfadec40ceff6c815c36156dd713d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213152/0000/RSGravitonToGammaGamma_kMpl02_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213152/0000/RSGravitonToGammaGamma_kMpl02_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl02_M_5125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5dd4796da9e219e006901673a897b9f0/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213150/0000/RSGravitonToGammaGamma_kMpl02_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213150/0000/RSGravitonToGammaGamma_kMpl02_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_5250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d03ed1c6ec7d460f517bd8249dc8d416/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213152/0000/RSGravitonToGammaGamma_kMpl02_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213152/0000/RSGravitonToGammaGamma_kMpl02_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_5375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e3de4ae9731e23dc84d1e04745f46bff/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213208/0000/RSGravitonToGammaGamma_kMpl02_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_5500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-32caba8644352c918bfa75beaf73fc7d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213210/0000/RSGravitonToGammaGamma_kMpl02_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213210/0000/RSGravitonToGammaGamma_kMpl02_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_5625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d8d2162502028a3f4fcf6194eb5494a9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213209/0000/RSGravitonToGammaGamma_kMpl02_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213209/0000/RSGravitonToGammaGamma_kMpl02_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_5875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5840a253adc1a482c3f3f3b88bb87e1d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213210/0000/RSGravitonToGammaGamma_kMpl02_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213210/0000/RSGravitonToGammaGamma_kMpl02_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_6000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2d3a5d3df4fa91838f689afa2dce006c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213211/0000/RSGravitonToGammaGamma_kMpl02_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213211/0000/RSGravitonToGammaGamma_kMpl02_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_6125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-13144c9ace43e6d7aad4d311f4c7713e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213212/0000/RSGravitonToGammaGamma_kMpl02_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213212/0000/RSGravitonToGammaGamma_kMpl02_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_6250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0df1d5f5b52575d935611f05a29adfc5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213212/0000/RSGravitonToGammaGamma_kMpl02_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213212/0000/RSGravitonToGammaGamma_kMpl02_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c762b859b25d93410de6d0de009d9d85/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213237/0000/RSGravitonToGammaGamma_kMpl02_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213237/0000/RSGravitonToGammaGamma_kMpl02_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_6375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2b2bdd0b9585111fe9a87adb08607f1d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213237/0000/RSGravitonToGammaGamma_kMpl02_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213237/0000/RSGravitonToGammaGamma_kMpl02_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_6500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fab70a3ea23650cd680c878bc6bcfe0f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213240/0000/RSGravitonToGammaGamma_kMpl02_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213240/0000/RSGravitonToGammaGamma_kMpl02_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_6625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-eb130b513e1bde9cab9b0319d7efb247/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213237/0000/RSGravitonToGammaGamma_kMpl02_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213237/0000/RSGravitonToGammaGamma_kMpl02_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_6750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f84499c14de5308912c464ae594db74c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213240/0000/RSGravitonToGammaGamma_kMpl02_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_6875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b9055a7ad113898a20ce60ad7df361a9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213236/0000/RSGravitonToGammaGamma_kMpl02_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213236/0000/RSGravitonToGammaGamma_kMpl02_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_7000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8081901ce1615fd610d478bb09456602/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213240/0000/RSGravitonToGammaGamma_kMpl02_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213240/0000/RSGravitonToGammaGamma_kMpl02_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9dd6881ab8adacace530a96620ee3173/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213237/0000/RSGravitonToGammaGamma_kMpl02_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213237/0000/RSGravitonToGammaGamma_kMpl02_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl02_M_875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2826c9d91ae01955783beaece6cb0176/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213305/0000/RSGravitonToGammaGamma_kMpl02_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl02_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213305/0000/RSGravitonToGammaGamma_kMpl02_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl035_M_1000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-39732b89933d98104f5a0ad75c18e202/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213305/0000/RSGravitonToGammaGamma_kMpl035_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213305/0000/RSGravitonToGammaGamma_kMpl035_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_1125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e1bd33514c3a96e2a01be344e6164e39/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213305/0000/RSGravitonToGammaGamma_kMpl035_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_1250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-046909f2587429b66dc1fea66d9ab634/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213307/0000/RSGravitonToGammaGamma_kMpl035_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213307/0000/RSGravitonToGammaGamma_kMpl035_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_1375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8e0dd4c6a73a84ad8ae9f48c77667295/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213305/0000/RSGravitonToGammaGamma_kMpl035_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213305/0000/RSGravitonToGammaGamma_kMpl035_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_1500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8ba0721e0846672c2b48d626145cbe05/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213307/0000/RSGravitonToGammaGamma_kMpl035_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213307/0000/RSGravitonToGammaGamma_kMpl035_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_1625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d4a0c900f6f553625f42f560f3821a44/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213305/0000/RSGravitonToGammaGamma_kMpl035_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213305/0000/RSGravitonToGammaGamma_kMpl035_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_1750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ab2de9e34b5bfbba7bc9478ea004f02d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213307/0000/RSGravitonToGammaGamma_kMpl035_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213307/0000/RSGravitonToGammaGamma_kMpl035_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_1875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-be4100f00d4f9615b0b198e0d349a0ee/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213342/0000/RSGravitonToGammaGamma_kMpl035_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213342/0000/RSGravitonToGammaGamma_kMpl035_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_2000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5741f107a9ec939babb342d8a1e483ea/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213336/0000/RSGravitonToGammaGamma_kMpl035_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213336/0000/RSGravitonToGammaGamma_kMpl035_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_2125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2bac2e478134c71d9cf7df17d66558e9/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213342/0000/RSGravitonToGammaGamma_kMpl035_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213342/0000/RSGravitonToGammaGamma_kMpl035_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_2250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b3aa53661a133c3696dc20b3b5394a77/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213333/0000/RSGravitonToGammaGamma_kMpl035_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213333/0000/RSGravitonToGammaGamma_kMpl035_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_2375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b92de5705220b4b200980ebc6730c26b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213337/0000/RSGravitonToGammaGamma_kMpl035_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213337/0000/RSGravitonToGammaGamma_kMpl035_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_2500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3f327917f1fa1f135b201dafeec0acc0/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213336/0000/RSGravitonToGammaGamma_kMpl035_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213336/0000/RSGravitonToGammaGamma_kMpl035_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_2625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e0dc810b5428066d3b519de1fd15752a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213342/0000/RSGravitonToGammaGamma_kMpl035_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213342/0000/RSGravitonToGammaGamma_kMpl035_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_2750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fe532faeec3af7e5143fc3a76a554832/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213335/0000/RSGravitonToGammaGamma_kMpl035_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213335/0000/RSGravitonToGammaGamma_kMpl035_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_3000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1ccda87fb6483d0dd9f660c6f185cd4d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213400/0000/RSGravitonToGammaGamma_kMpl035_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213400/0000/RSGravitonToGammaGamma_kMpl035_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl035_M_3500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-92e17b9775b526d2455eca4ae8d3c48a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213400/0000/RSGravitonToGammaGamma_kMpl035_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_3625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d07628d8c8fdbe3a7f706c7f45a20e39/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213400/0000/RSGravitonToGammaGamma_kMpl035_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213400/0000/RSGravitonToGammaGamma_kMpl035_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_3750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-67d955b3baf43c6546c98ae5bae44c3d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213401/0000/RSGravitonToGammaGamma_kMpl035_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213401/0000/RSGravitonToGammaGamma_kMpl035_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_3875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c79faa9fc98419af18d51473f886a990/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213405/0000/RSGravitonToGammaGamma_kMpl035_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213405/0000/RSGravitonToGammaGamma_kMpl035_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl035_M_4000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-54001f3318e2ae4f83861c1dcecb9e90/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213405/0000/RSGravitonToGammaGamma_kMpl035_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213405/0000/RSGravitonToGammaGamma_kMpl035_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_4125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c3721679e4e753146e2baa732182e260/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213405/0000/RSGravitonToGammaGamma_kMpl035_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213405/0000/RSGravitonToGammaGamma_kMpl035_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_4250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-41a042f8d880d2552c374d95f16c1d79/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213425/0000/RSGravitonToGammaGamma_kMpl035_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213425/0000/RSGravitonToGammaGamma_kMpl035_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_4375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-4bc0455bc27cdd2b117611c8cb18837d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213426/0000/RSGravitonToGammaGamma_kMpl035_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213426/0000/RSGravitonToGammaGamma_kMpl035_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_4500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-77b7493a1980fb92913beee4c9854c59/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213426/0000/RSGravitonToGammaGamma_kMpl035_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_4625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2322022b9d626c04cc3c432fb5a73fd3/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213427/0000/RSGravitonToGammaGamma_kMpl035_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213427/0000/RSGravitonToGammaGamma_kMpl035_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_4750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8493a65b072763e2d4d5f2e2c4830f29/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213426/0000/RSGravitonToGammaGamma_kMpl035_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213426/0000/RSGravitonToGammaGamma_kMpl035_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_4875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f382909b4f38b901d04e40ec4a2ff080/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213428/0000/RSGravitonToGammaGamma_kMpl035_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213428/0000/RSGravitonToGammaGamma_kMpl035_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl035_M_5000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c968b5ba0c96fa718c72b7df800108a2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213428/0000/RSGravitonToGammaGamma_kMpl035_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213428/0000/RSGravitonToGammaGamma_kMpl035_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c40656b1fff5178b53de481f31fad487/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213428/0000/RSGravitonToGammaGamma_kMpl035_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213428/0000/RSGravitonToGammaGamma_kMpl035_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_5125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-79268ca4954e69bb486dae42d511829a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213444/0000/RSGravitonToGammaGamma_kMpl035_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213444/0000/RSGravitonToGammaGamma_kMpl035_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_5250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7a551ffad29d956da26f65cb0b921016/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213446/0000/RSGravitonToGammaGamma_kMpl035_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213446/0000/RSGravitonToGammaGamma_kMpl035_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_5375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-24d7d68e61c7692d11ae3b2c8fc3c3ad/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213446/0000/RSGravitonToGammaGamma_kMpl035_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_5500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-90a34be540c32c9fe414cd578cf492b6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213446/0000/RSGravitonToGammaGamma_kMpl035_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213446/0000/RSGravitonToGammaGamma_kMpl035_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_5625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-846b966a0ea2f42ebe072ba9787b9fd7/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213448/0000/RSGravitonToGammaGamma_kMpl035_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213448/0000/RSGravitonToGammaGamma_kMpl035_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_5750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-4613c69b9c35116090bcdc89d4cb0545/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213448/0000/RSGravitonToGammaGamma_kMpl035_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_5875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-48ab8f36923a9c939b9048b1f0c065d2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213448/0000/RSGravitonToGammaGamma_kMpl035_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213448/0000/RSGravitonToGammaGamma_kMpl035_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_6000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a0fe9847f2f2be3d9d25126eeec470de/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213446/0000/RSGravitonToGammaGamma_kMpl035_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213446/0000/RSGravitonToGammaGamma_kMpl035_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_6125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5a202adbb56b391f36173af0aec07edb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213518/0000/RSGravitonToGammaGamma_kMpl035_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213518/0000/RSGravitonToGammaGamma_kMpl035_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_6250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a0492ff143d0db70a2ede0ef5ae4defd/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213516/0000/RSGravitonToGammaGamma_kMpl035_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213516/0000/RSGravitonToGammaGamma_kMpl035_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-58519c3a9b63398cd926011016edf795/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213515/0000/RSGravitonToGammaGamma_kMpl035_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213515/0000/RSGravitonToGammaGamma_kMpl035_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_6375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8d2d5b9005cf75007322b36a6b10327d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213516/0000/RSGravitonToGammaGamma_kMpl035_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_6500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9a7c22e83c9f8df44b925b7afa84890e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213518/0000/RSGravitonToGammaGamma_kMpl035_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213518/0000/RSGravitonToGammaGamma_kMpl035_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_6625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-be1265495dc046c49cc088e458b5d348/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213515/0000/RSGravitonToGammaGamma_kMpl035_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213515/0000/RSGravitonToGammaGamma_kMpl035_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_6750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-922045f4c01d60a46330dfe4a736a691/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213518/0000/RSGravitonToGammaGamma_kMpl035_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213518/0000/RSGravitonToGammaGamma_kMpl035_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_6875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c5213d4afa55adb2ca70a48503ab4710/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213516/0000/RSGravitonToGammaGamma_kMpl035_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213516/0000/RSGravitonToGammaGamma_kMpl035_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_7000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8a9bda9e7181946be589686fe9d6d25b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213538/0000/RSGravitonToGammaGamma_kMpl035_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213538/0000/RSGravitonToGammaGamma_kMpl035_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl035_M_750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fe37ac48c327627c82d30837f44370a3/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213537/0000/RSGravitonToGammaGamma_kMpl035_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213537/0000/RSGravitonToGammaGamma_kMpl035_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl035_M_875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f6ec94ddc53207a52b45546dedd78658/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213537/0000/RSGravitonToGammaGamma_kMpl035_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl035_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213537/0000/RSGravitonToGammaGamma_kMpl035_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_1000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c18bd9b509e479bb3502fdd71f573dae/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213537/0000/RSGravitonToGammaGamma_kMpl03_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213537/0000/RSGravitonToGammaGamma_kMpl03_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_1125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f7307571cb59513c8ac005936b53b89b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213537/0000/RSGravitonToGammaGamma_kMpl03_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213537/0000/RSGravitonToGammaGamma_kMpl03_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_1250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-214ba0ff56a28ac4d95d795cc3c373c4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213554/0000/RSGravitonToGammaGamma_kMpl03_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213554/0000/RSGravitonToGammaGamma_kMpl03_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_1375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-50a4e44b1c6e72634256f67c38827810/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213554/0000/RSGravitonToGammaGamma_kMpl03_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213554/0000/RSGravitonToGammaGamma_kMpl03_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_1500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b2594d29e21e60c4eaae49b7523878ef/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213554/0000/RSGravitonToGammaGamma_kMpl03_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213554/0000/RSGravitonToGammaGamma_kMpl03_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_1625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a6bc986c18d2579bbe26d7e6b650cb02/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213611/0000/RSGravitonToGammaGamma_kMpl03_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213611/0000/RSGravitonToGammaGamma_kMpl03_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_1750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3eeea7f41fe8e6ca997521caf16d4d6f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213611/0000/RSGravitonToGammaGamma_kMpl03_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213611/0000/RSGravitonToGammaGamma_kMpl03_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_1875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cad044c4a4f0e638055f886fb76281ce/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213623/0000/RSGravitonToGammaGamma_kMpl03_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213623/0000/RSGravitonToGammaGamma_kMpl03_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_2000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-01af3038223d6e4733d2e713899ad884/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213636/0000/RSGravitonToGammaGamma_kMpl03_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_213636/0000/RSGravitonToGammaGamma_kMpl03_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_2125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-56947872b2284373a07f1daf032c4e30/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214034/0000/RSGravitonToGammaGamma_kMpl03_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214034/0000/RSGravitonToGammaGamma_kMpl03_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl03_M_2250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b4c963db4126da6dfc62dd3fff38e44c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214034/0000/RSGravitonToGammaGamma_kMpl03_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214034/0000/RSGravitonToGammaGamma_kMpl03_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_2375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6da55f447364a78e4e399eee891b7cf4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214034/0000/RSGravitonToGammaGamma_kMpl03_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214034/0000/RSGravitonToGammaGamma_kMpl03_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_2500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a7fe493084db84941ffed54dc5bbe25b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214048/0000/RSGravitonToGammaGamma_kMpl03_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214048/0000/RSGravitonToGammaGamma_kMpl03_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_2625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0954e55f6b9058becccaa68afd13abed/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214048/0000/RSGravitonToGammaGamma_kMpl03_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214048/0000/RSGravitonToGammaGamma_kMpl03_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_2750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0139dabc77b6c60c7ae4412ebd28ab76/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214106/0000/RSGravitonToGammaGamma_kMpl03_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214106/0000/RSGravitonToGammaGamma_kMpl03_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_2875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f02140e2719796670a76615ec81a12ad/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214122/0000/RSGravitonToGammaGamma_kMpl03_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214122/0000/RSGravitonToGammaGamma_kMpl03_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_3000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-aa6dab6486ff8b0fca0cc3d4bb68983b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214150/0000/RSGravitonToGammaGamma_kMpl03_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214150/0000/RSGravitonToGammaGamma_kMpl03_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_3500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-bff14d20e99bae26d332c7d83062615b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214612/0000/RSGravitonToGammaGamma_kMpl03_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214612/0000/RSGravitonToGammaGamma_kMpl03_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl03_M_3625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e55d21302a60d2e34c085ec353c660b7/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214612/0000/RSGravitonToGammaGamma_kMpl03_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214612/0000/RSGravitonToGammaGamma_kMpl03_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_3750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-158bf0a076ffe7b4509c7eacc67987ac/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214612/0000/RSGravitonToGammaGamma_kMpl03_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214612/0000/RSGravitonToGammaGamma_kMpl03_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_3875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8dfb8702ef2e27cc071b338963dbce91/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214734/0000/RSGravitonToGammaGamma_kMpl03_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_4000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f69a11ca45516ec3b2ef7c802e9a0460/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214734/0000/RSGravitonToGammaGamma_kMpl03_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214734/0000/RSGravitonToGammaGamma_kMpl03_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_4125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-008b4c3dd4be7f637b9f9603d440c302/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214742/0000/RSGravitonToGammaGamma_kMpl03_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214742/0000/RSGravitonToGammaGamma_kMpl03_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl03_M_4250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-31df351380a250a9130b3c0ee972e8da/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214742/0000/RSGravitonToGammaGamma_kMpl03_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214742/0000/RSGravitonToGammaGamma_kMpl03_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_4375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ca9351c31f4281d187618f3894d0d839/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214742/0000/RSGravitonToGammaGamma_kMpl03_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214742/0000/RSGravitonToGammaGamma_kMpl03_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_4500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5f692b35f5a409e61aff4b534866c418/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214753/0000/RSGravitonToGammaGamma_kMpl03_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214753/0000/RSGravitonToGammaGamma_kMpl03_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_4625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fb698c587c73c45d73bcaee8a33446c1/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214753/0000/RSGravitonToGammaGamma_kMpl03_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214753/0000/RSGravitonToGammaGamma_kMpl03_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_4750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-907f8577bf48bd5a088acc10f252591c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214759/0000/RSGravitonToGammaGamma_kMpl03_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214759/0000/RSGravitonToGammaGamma_kMpl03_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_4875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2d923fa1e578e0dbcd3760f42919a2c3/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214759/0000/RSGravitonToGammaGamma_kMpl03_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214759/0000/RSGravitonToGammaGamma_kMpl03_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_5000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-69479bc7504835f0fbfd30e473295ec6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214822/0000/RSGravitonToGammaGamma_kMpl03_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214822/0000/RSGravitonToGammaGamma_kMpl03_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-78a9a3ed7a50c7729a7bebad2a43cfd7/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214819/0000/RSGravitonToGammaGamma_kMpl03_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_5125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8f735b29a99fc59c002e3820fd7df59d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214819/0000/RSGravitonToGammaGamma_kMpl03_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214819/0000/RSGravitonToGammaGamma_kMpl03_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_5250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-77944c9d01827f4de759b31953d394b6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214817/0000/RSGravitonToGammaGamma_kMpl03_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214817/0000/RSGravitonToGammaGamma_kMpl03_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl03_M_5375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5e25cb3d98f8572547d1ee44b633ac9a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214818/0000/RSGravitonToGammaGamma_kMpl03_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_5500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-251d89c8ea9144bb24c49c2120675280/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214819/0000/RSGravitonToGammaGamma_kMpl03_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214819/0000/RSGravitonToGammaGamma_kMpl03_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_5625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c53d79b03c4dd44d5e9321e7ced0fa5f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214823/0000/RSGravitonToGammaGamma_kMpl03_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214823/0000/RSGravitonToGammaGamma_kMpl03_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl03_M_5750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5cf5c7af3091eb47b8f229a3a93dd896/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214823/0000/RSGravitonToGammaGamma_kMpl03_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214823/0000/RSGravitonToGammaGamma_kMpl03_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_5875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-79421b6cb81af1a4ab3b4d31a21064d8/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214832/0000/RSGravitonToGammaGamma_kMpl03_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214832/0000/RSGravitonToGammaGamma_kMpl03_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_6000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8b1cfabd080ea0bf73746ad67a9d1067/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214837/0000/RSGravitonToGammaGamma_kMpl03_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214837/0000/RSGravitonToGammaGamma_kMpl03_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_6125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5e6305ee437a1466b11fab839df5221c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214842/0000/RSGravitonToGammaGamma_kMpl03_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_6250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-53605c17b3ee9117092896d112bcc3c5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214837/0000/RSGravitonToGammaGamma_kMpl03_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214837/0000/RSGravitonToGammaGamma_kMpl03_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7a2272a351faed8cdf854aedcc128777/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214837/0000/RSGravitonToGammaGamma_kMpl03_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214837/0000/RSGravitonToGammaGamma_kMpl03_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_6375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b162843f903d97e649af113c52e75287/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214840/0000/RSGravitonToGammaGamma_kMpl03_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214840/0000/RSGravitonToGammaGamma_kMpl03_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_6625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-4856ae8c5941b98bda08761ebc855d2d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214840/0000/RSGravitonToGammaGamma_kMpl03_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214840/0000/RSGravitonToGammaGamma_kMpl03_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_6750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fd91d6920f671399eeac6b324032ae4a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214854/0000/RSGravitonToGammaGamma_kMpl03_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214854/0000/RSGravitonToGammaGamma_kMpl03_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_6875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2cb01eff59922721235be858e4080720/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214856/0000/RSGravitonToGammaGamma_kMpl03_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214856/0000/RSGravitonToGammaGamma_kMpl03_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_7000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0719b11b45a7a09b9ddd6bbc3305ac7c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214854/0000/RSGravitonToGammaGamma_kMpl03_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214854/0000/RSGravitonToGammaGamma_kMpl03_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl03_M_750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a1a9eae6e26c409e0b91f822a439783b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214904/0000/RSGravitonToGammaGamma_kMpl03_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214904/0000/RSGravitonToGammaGamma_kMpl03_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl03_M_875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e43c68543b9da198ad1d6a5c0dd65cfe/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214857/0000/RSGravitonToGammaGamma_kMpl03_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl03_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214857/0000/RSGravitonToGammaGamma_kMpl03_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_1000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0b335c49a3f097ab320b42064aa7ffea/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214856/0000/RSGravitonToGammaGamma_kMpl04_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214856/0000/RSGravitonToGammaGamma_kMpl04_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_1125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0b7d48f4bd3fbf56b17d2f8c6c861e41/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214857/0000/RSGravitonToGammaGamma_kMpl04_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214857/0000/RSGravitonToGammaGamma_kMpl04_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl04_M_1250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-adaf018d7865285ecc8de0ecdf1d5276/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214857/0000/RSGravitonToGammaGamma_kMpl04_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214857/0000/RSGravitonToGammaGamma_kMpl04_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_1375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-dc54f0f4271fe3996572dcbf0024305c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214915/0000/RSGravitonToGammaGamma_kMpl04_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214915/0000/RSGravitonToGammaGamma_kMpl04_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_1500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-68cdfe54ab6bd90c583099f7fe65873c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214923/0000/RSGravitonToGammaGamma_kMpl04_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_1625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-644928727fd99d4f539947660a169c6f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214921/0000/RSGravitonToGammaGamma_kMpl04_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214921/0000/RSGravitonToGammaGamma_kMpl04_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_1750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ba50219dca34f36f8e0011d2d2dfbe74/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214915/0000/RSGravitonToGammaGamma_kMpl04_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214915/0000/RSGravitonToGammaGamma_kMpl04_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_1875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ad2669e2bbf3e06ee59369c4668bc9ab/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214920/0000/RSGravitonToGammaGamma_kMpl04_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214920/0000/RSGravitonToGammaGamma_kMpl04_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_2000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-010a909cd862495ac19ffd452c615fe2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214921/0000/RSGravitonToGammaGamma_kMpl04_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214921/0000/RSGravitonToGammaGamma_kMpl04_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_2125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f116ddb588be447086cf5ccfc7d4902a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214921/0000/RSGravitonToGammaGamma_kMpl04_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214921/0000/RSGravitonToGammaGamma_kMpl04_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_2250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-aecb649fba5eb84b5653518f981f2147/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214921/0000/RSGravitonToGammaGamma_kMpl04_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214921/0000/RSGravitonToGammaGamma_kMpl04_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_2375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cbb3858b9947d638fb7a2174a794cb9e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214929/0000/RSGravitonToGammaGamma_kMpl04_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214929/0000/RSGravitonToGammaGamma_kMpl04_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_2500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-45bd1f2cd36510b1860de39866ef7d3b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214929/0000/RSGravitonToGammaGamma_kMpl04_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_2625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3222862d70f465fb1d933f066f9c98dc/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214940/0000/RSGravitonToGammaGamma_kMpl04_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_2750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8c927a4422514dd9d33eca44d1f74a6f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214940/0000/RSGravitonToGammaGamma_kMpl04_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214940/0000/RSGravitonToGammaGamma_kMpl04_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_2875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-67a4f22d4f94d47531b78626f185aa07/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214941/0000/RSGravitonToGammaGamma_kMpl04_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214941/0000/RSGravitonToGammaGamma_kMpl04_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_3000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-719b102b0d0bb8d23247f00d41d08a49/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214940/0000/RSGravitonToGammaGamma_kMpl04_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_3000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214940/0000/RSGravitonToGammaGamma_kMpl04_M_3000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_3500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a58e831d63d962293de4d104f0a105b4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214941/0000/RSGravitonToGammaGamma_kMpl04_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214941/0000/RSGravitonToGammaGamma_kMpl04_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_3625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-aa8d36aaa6173438c297d3a0bd2da322/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214942/0000/RSGravitonToGammaGamma_kMpl04_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214942/0000/RSGravitonToGammaGamma_kMpl04_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_3750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a45b6a3307d39e2f6ff4960ed042ce13/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214943/0000/RSGravitonToGammaGamma_kMpl04_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214943/0000/RSGravitonToGammaGamma_kMpl04_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_3875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8590a0dc2533e000d997d28f56a15fa7/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214943/0000/RSGravitonToGammaGamma_kMpl04_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_214943/0000/RSGravitonToGammaGamma_kMpl04_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_4000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-180f9cf24d49f173b221585e0ab92867/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215005/0000/RSGravitonToGammaGamma_kMpl04_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215005/0000/RSGravitonToGammaGamma_kMpl04_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_4125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6fd6d6138d65b0b8210228943b74228b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215009/0000/RSGravitonToGammaGamma_kMpl04_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215009/0000/RSGravitonToGammaGamma_kMpl04_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_4250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f7bb9476752d399b99d864e23ee262e2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215005/0000/RSGravitonToGammaGamma_kMpl04_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215005/0000/RSGravitonToGammaGamma_kMpl04_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_4500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-635283641c46488fce11b4f4aa8a157f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215006/0000/RSGravitonToGammaGamma_kMpl04_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215006/0000/RSGravitonToGammaGamma_kMpl04_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_4625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-dd465e81c6a99bf99383a94dd3e58c26/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215009/0000/RSGravitonToGammaGamma_kMpl04_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215009/0000/RSGravitonToGammaGamma_kMpl04_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl04_M_4750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2597759a6c5f0b22d6bf921a98d3693c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215008/0000/RSGravitonToGammaGamma_kMpl04_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215008/0000/RSGravitonToGammaGamma_kMpl04_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_4875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e518f0aa017cff9c3a7883f659cd376f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215006/0000/RSGravitonToGammaGamma_kMpl04_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215006/0000/RSGravitonToGammaGamma_kMpl04_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_5000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-5026737330b82dfae2af48be214b667a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215034/0000/RSGravitonToGammaGamma_kMpl04_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215034/0000/RSGravitonToGammaGamma_kMpl04_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-36157831e3a25062f74de3d33552d264/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215028/0000/RSGravitonToGammaGamma_kMpl04_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215028/0000/RSGravitonToGammaGamma_kMpl04_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_5125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cf71791a4c7a43a648acf9628b0346e5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215034/0000/RSGravitonToGammaGamma_kMpl04_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215034/0000/RSGravitonToGammaGamma_kMpl04_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_5250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-971ad14e9aae2c8521eb63b728cda3af/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215034/0000/RSGravitonToGammaGamma_kMpl04_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215034/0000/RSGravitonToGammaGamma_kMpl04_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_5375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-bf53518dff005399a0053212a78175c3/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215028/0000/RSGravitonToGammaGamma_kMpl04_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215028/0000/RSGravitonToGammaGamma_kMpl04_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_5500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b1ae79890d26493540b353422fba32b2/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215035/0000/RSGravitonToGammaGamma_kMpl04_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_5625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2d39916145a3739e5cf77088d945d181/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215034/0000/RSGravitonToGammaGamma_kMpl04_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215034/0000/RSGravitonToGammaGamma_kMpl04_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl04_M_5750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-fda488b205e7a1867203579fedcbd1f7/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215034/0000/RSGravitonToGammaGamma_kMpl04_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_5875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3ab035156e4cffd478e1aed516cdf640/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215045/0000/RSGravitonToGammaGamma_kMpl04_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215045/0000/RSGravitonToGammaGamma_kMpl04_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_6000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b62639d1fe9353942ddfee0aa4f390d7/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215045/0000/RSGravitonToGammaGamma_kMpl04_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215045/0000/RSGravitonToGammaGamma_kMpl04_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_6125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ebc62e7583d07ee2c9085cc1c6d3bd97/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215054/0000/RSGravitonToGammaGamma_kMpl04_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215054/0000/RSGravitonToGammaGamma_kMpl04_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_6250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-f820d8154afa38c1e859f634fc11911a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215055/0000/RSGravitonToGammaGamma_kMpl04_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-041cd8a5479f8e9e2392d672f4bdc372/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215055/0000/RSGravitonToGammaGamma_kMpl04_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215055/0000/RSGravitonToGammaGamma_kMpl04_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_6375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-470d9fd1fef3a3bd7b6efa64ae6e8a2d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215055/0000/RSGravitonToGammaGamma_kMpl04_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215055/0000/RSGravitonToGammaGamma_kMpl04_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_6500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-473641109f6b58c82a8e8cdc830e4fce/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215056/0000/RSGravitonToGammaGamma_kMpl04_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215056/0000/RSGravitonToGammaGamma_kMpl04_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_6625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9a1da5f0d0898f991e5e4ca4fa3a19e8/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215056/0000/RSGravitonToGammaGamma_kMpl04_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215056/0000/RSGravitonToGammaGamma_kMpl04_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_6750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-32115b09efbfc2500c4a2320c0b1f9bc/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215105/0000/RSGravitonToGammaGamma_kMpl04_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215105/0000/RSGravitonToGammaGamma_kMpl04_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_6875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-4956abe97e717170847e257d9a988d44/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215105/0000/RSGravitonToGammaGamma_kMpl04_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215105/0000/RSGravitonToGammaGamma_kMpl04_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_7000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e397bfe7aa1492aba18e5db8993bf7ce/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215120/0000/RSGravitonToGammaGamma_kMpl04_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215120/0000/RSGravitonToGammaGamma_kMpl04_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl04_M_750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-37953f513d15090223ff3ee5d63f6764/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215120/0000/RSGravitonToGammaGamma_kMpl04_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215120/0000/RSGravitonToGammaGamma_kMpl04_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl04_M_875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-96cd166d650701335ec43532080a770a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215120/0000/RSGravitonToGammaGamma_kMpl04_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl04_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215120/0000/RSGravitonToGammaGamma_kMpl04_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_1000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-15b2258f702738c56b87d5b0048e045b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215120/0000/RSGravitonToGammaGamma_kMpl06_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215120/0000/RSGravitonToGammaGamma_kMpl06_M_1000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_1125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-87d1d813a00bd8a8f0b4f1ac5997e760/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215120/0000/RSGravitonToGammaGamma_kMpl06_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215120/0000/RSGravitonToGammaGamma_kMpl06_M_1125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_1250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9b562b846b04462ca9d2cf90e3ee15f6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215117/0000/RSGravitonToGammaGamma_kMpl06_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215117/0000/RSGravitonToGammaGamma_kMpl06_M_1250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_1375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-18abd1bd111d85400e3a0c6138767164/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215130/0000/RSGravitonToGammaGamma_kMpl06_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215130/0000/RSGravitonToGammaGamma_kMpl06_M_1375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_1500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d2d0e1f560099505fd9104fa78af5bbb/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215130/0000/RSGravitonToGammaGamma_kMpl06_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215130/0000/RSGravitonToGammaGamma_kMpl06_M_1500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_1625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0ca58ad21b9546ff148dab8cf6a3674b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215133/0000/RSGravitonToGammaGamma_kMpl06_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215133/0000/RSGravitonToGammaGamma_kMpl06_M_1625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_1750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e73919a56b63f29dfff6869294ca1e06/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215141/0000/RSGravitonToGammaGamma_kMpl06_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215141/0000/RSGravitonToGammaGamma_kMpl06_M_1750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_1875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-afd982695f5b34ed6806b485f0191a72/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215141/0000/RSGravitonToGammaGamma_kMpl06_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_1875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215141/0000/RSGravitonToGammaGamma_kMpl06_M_1875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_2000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9601469998fd6cc9efa4cb4d6af41c5d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215141/0000/RSGravitonToGammaGamma_kMpl06_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215141/0000/RSGravitonToGammaGamma_kMpl06_M_2000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_2125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cf13c904044073edcb1fa9f2ffe4534c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215141/0000/RSGravitonToGammaGamma_kMpl06_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215141/0000/RSGravitonToGammaGamma_kMpl06_M_2125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_2250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b5854a41d3f778174b3600d178893339/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215141/0000/RSGravitonToGammaGamma_kMpl06_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215141/0000/RSGravitonToGammaGamma_kMpl06_M_2250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl06_M_2375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1d957efc13054a5651d799062ec7e176/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215145/0000/RSGravitonToGammaGamma_kMpl06_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215145/0000/RSGravitonToGammaGamma_kMpl06_M_2375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_2500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-dc3845efbac586538e22510fc9661732/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215145/0000/RSGravitonToGammaGamma_kMpl06_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215145/0000/RSGravitonToGammaGamma_kMpl06_M_2500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_2625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-cbac19cc8de25feca28eac9b27e4d914/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215158/0000/RSGravitonToGammaGamma_kMpl06_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215158/0000/RSGravitonToGammaGamma_kMpl06_M_2625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_2750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-eb81b6e45c9d39356bdf7cb7ff1cf8e4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215204/0000/RSGravitonToGammaGamma_kMpl06_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215204/0000/RSGravitonToGammaGamma_kMpl06_M_2750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_2875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-6e96c9f854120244bc301d36dfa63008/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215200/0000/RSGravitonToGammaGamma_kMpl06_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_2875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215200/0000/RSGravitonToGammaGamma_kMpl06_M_2875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_3500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2f531a7fe8469aca072984232c2c93ff/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215204/0000/RSGravitonToGammaGamma_kMpl06_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_3500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215204/0000/RSGravitonToGammaGamma_kMpl06_M_3500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_3625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ca221a6f088bf0f7a150c2405c163179/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215204/0000/RSGravitonToGammaGamma_kMpl06_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_3625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215204/0000/RSGravitonToGammaGamma_kMpl06_M_3625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_3750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-92149f26718c57d3cc0b760e8d472482/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215204/0000/RSGravitonToGammaGamma_kMpl06_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_3750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215204/0000/RSGravitonToGammaGamma_kMpl06_M_3750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_3875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e889bfcfd0e648d1b45b14232a6f994c/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_3875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215204/0000/RSGravitonToGammaGamma_kMpl06_M_3875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_4000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8ead1307563ffe01cf4e49adacfc06ae/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215232/0000/RSGravitonToGammaGamma_kMpl06_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215232/0000/RSGravitonToGammaGamma_kMpl06_M_4000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_4125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8664addb32ee309f4cc6b1b7b0d77014/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215233/0000/RSGravitonToGammaGamma_kMpl06_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215233/0000/RSGravitonToGammaGamma_kMpl06_M_4125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_4250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-501ca753331dafe8ff213a78f7b3f973/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215234/0000/RSGravitonToGammaGamma_kMpl06_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215234/0000/RSGravitonToGammaGamma_kMpl06_M_4250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_4375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ca6b42ff835f8030e7215ff18b04a129/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215231/0000/RSGravitonToGammaGamma_kMpl06_M_4375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_4500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1cbc67b9683112582b16545ab897140e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215231/0000/RSGravitonToGammaGamma_kMpl06_M_4500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_4625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-7795870936429cbb347fe03688619572/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215233/0000/RSGravitonToGammaGamma_kMpl06_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215233/0000/RSGravitonToGammaGamma_kMpl06_M_4625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl06_M_4750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8936b37a0861662475c3ddfe0af05f41/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215234/0000/RSGravitonToGammaGamma_kMpl06_M_4750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_4875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-eb09b09ee9abf85270be69e4aa037ab4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_4875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215234/0000/RSGravitonToGammaGamma_kMpl06_M_4875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_5000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-d9cbe78b5a41b459637337ce079c6570/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215302/0000/RSGravitonToGammaGamma_kMpl06_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215302/0000/RSGravitonToGammaGamma_kMpl06_M_5000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9e5a099b7dcfc8f4c5b13b958fe71488/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215302/0000/RSGravitonToGammaGamma_kMpl06_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215302/0000/RSGravitonToGammaGamma_kMpl06_M_500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_5125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-a8b2d452c3ee4e28898fa81cf11c21a4/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215301/0000/RSGravitonToGammaGamma_kMpl06_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215301/0000/RSGravitonToGammaGamma_kMpl06_M_5125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl06_M_5250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-b44d88e0bd3583a38c00bd31d1c70c8d/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215304/0000/RSGravitonToGammaGamma_kMpl06_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215304/0000/RSGravitonToGammaGamma_kMpl06_M_5250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_5375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-8e398e85803d953ae0fd0a703f7fee83/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215304/0000/RSGravitonToGammaGamma_kMpl06_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215304/0000/RSGravitonToGammaGamma_kMpl06_M_5375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_5500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-3101b61da582fc1c01b988c727ff1686/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215302/0000/RSGravitonToGammaGamma_kMpl06_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215302/0000/RSGravitonToGammaGamma_kMpl06_M_5500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_5625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-0bf45d2edd510de8f22407b98b8aa3d3/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215301/0000/RSGravitonToGammaGamma_kMpl06_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215301/0000/RSGravitonToGammaGamma_kMpl06_M_5625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_5750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c36e75bb319258a2f3aa7084bdeee176/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215304/0000/RSGravitonToGammaGamma_kMpl06_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215304/0000/RSGravitonToGammaGamma_kMpl06_M_5750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_5875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-671be6c3a9712054d52b0b92c23c6540/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215332/0000/RSGravitonToGammaGamma_kMpl06_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_5875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215332/0000/RSGravitonToGammaGamma_kMpl06_M_5875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl06_M_6000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e11b4631fffb2fbed243dc4732caac59/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215327/0000/RSGravitonToGammaGamma_kMpl06_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215327/0000/RSGravitonToGammaGamma_kMpl06_M_6000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_6125_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-2eb53f81697f8ac64856f75b55e2b014/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215331/0000/RSGravitonToGammaGamma_kMpl06_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6125_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215331/0000/RSGravitonToGammaGamma_kMpl06_M_6125_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_6250_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1b32083499b5321818a8d270feaeb400/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215332/0000/RSGravitonToGammaGamma_kMpl06_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6250_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215332/0000/RSGravitonToGammaGamma_kMpl06_M_6250_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-1a9bb8abddc33a4e5257d7e6b7826596/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215331/0000/RSGravitonToGammaGamma_kMpl06_M_625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_6375_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-ca145f42c2ea90cd65bdf916e2aee9a5/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215329/0000/RSGravitonToGammaGamma_kMpl06_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6375_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215329/0000/RSGravitonToGammaGamma_kMpl06_M_6375_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl06_M_6500_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-78d3cf282f077d12cfcf271be564940e/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215331/0000/RSGravitonToGammaGamma_kMpl06_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6500_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215331/0000/RSGravitonToGammaGamma_kMpl06_M_6500_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl06_M_6625_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-76b98c74244c6784c8749d90182c094b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215331/0000/RSGravitonToGammaGamma_kMpl06_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6625_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215331/0000/RSGravitonToGammaGamma_kMpl06_M_6625_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_6750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e71d3e1b115e94db55b419ef9866d57b/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215352/0000/RSGravitonToGammaGamma_kMpl06_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215352/0000/RSGravitonToGammaGamma_kMpl06_M_6750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl06_M_6875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-c37b3b6ec810a725941876e970e692d6/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215352/0000/RSGravitonToGammaGamma_kMpl06_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_6875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215352/0000/RSGravitonToGammaGamma_kMpl06_M_6875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_7000_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-e739a531b8f2960443858741370bdc4a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215352/0000/RSGravitonToGammaGamma_kMpl06_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_7000_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215352/0000/RSGravitonToGammaGamma_kMpl06_M_7000_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ], 
+        "vetted": false
+    }, 
+    "/RSGravitonToGG_kMpl06_M_750_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-9cbe6f4cab3f1d17216b0813ffc4be5a/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215352/0000/RSGravitonToGammaGamma_kMpl06_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_750_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215352/0000/RSGravitonToGammaGamma_kMpl06_M_750_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }, 
+    "/RSGravitonToGG_kMpl06_M_875_TuneCUEP8M1_13TeV_pythia8/musella-CMSSW_7_4_15-Private-GEN-43283996ef57058e99b2686bd432bb9f/USER": {
+        "files": [
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215351/0000/RSGravitonToGammaGamma_kMpl06_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_1.root", 
+                "nevents": 25000
+            }, 
+            {
+                "name": "/store/user/musella/RSGravitonToGG_kMpl06_M_875_TuneCUEP8M1_13TeV_pythia8/CMSSW_7_4_15-Private-GEN/151020_215351/0000/RSGravitonToGammaGamma_kMpl06_M_875_TuneCUEP8M1_13TeV_pythia8_GEN_2.root", 
+                "nevents": 25000
+            }
+        ]
+    }
+}

--- a/MetaData/work/analysis_microAOD.py
+++ b/MetaData/work/analysis_microAOD.py
@@ -46,7 +46,8 @@ process.source = cms.Source("PoolSource",
         ## "/store/data/Run2015B/DoubleEG/MINIAOD/PromptReco-v1/000/251/244/00000/C47A9CF9-6227-E511-908E-02163E014509.root"
         ## "/store/data/Run2015D/DoubleEG/MINIAOD/PromptReco-v3/000/256/630/00000/827EBF7D-5D5F-E511-A2A8-02163E01454A.root"
         ## "root://eoscms//eos/cms/store/mc/RunIISpring15DR74/ADDGravToGG_MS-6000_NED-4_KK-1_M-2000To4000_13TeV-sherpa/MINIAODSIM/Asympt25ns_MCRUN2_74_V9-v1/20000/76CA81A9-1024-E511-8D9F-3417EBE6471D.root"
-        "/store/mc/RunIISpring15DR74/RSGravToGG_kMpl-001_M-6000_TuneCUEP8M1_13TeV-pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v1/30000/3A9530E2-292B-E511-9F05-003048FFCB8C.root"
+        ## "/store/mc/RunIISpring15DR74/RSGravToGG_kMpl-001_M-6000_TuneCUEP8M1_13TeV-pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v1/30000/3A9530E2-292B-E511-9F05-003048FFCB8C.root"
+        '/store/data/Run2015D/DoubleEG/MINIAOD/05Oct2015-v1/50000/0014E86F-656F-E511-9D3F-002618943831.root'
         )
                             )
 
@@ -148,9 +149,11 @@ process.out.outputCommands.extend([### "keep *_eventCount_*_*",
                                     "drop *_flashggFinalEGamma_*_*",
                                     "drop *_flashggPreselectedDiPhotons_*_*",
                                     "keep *_reducedEgamma_*_*",
+                                    "drop *_reducedEgamma_reduced*RecHits_*",
                                     "keep *_flashggElectrons_*_*",
                                     "drop *_flashggSelectedElectrons_*_*",
-                                    "keep *_BeamHaloSummary_*_*"
+                                    "keep *_BeamHaloSummary_*_*",
+                                    "keep *_slimmedAddPileupInfo_*_*"
                                     ]
                                    )
 process.out.outputCommands.extend(microAODHLTOutputCommand)


### PR DESCRIPTION
- Essentially complete re-miniAOD production. Catalog: EXOSpring15_7415_v2_38T
  - Data: 
    +-------+------+-------+-------+-------------------+------------------+
    | nfill | nrun |  nls  |  ncms | totdelivered(/ub) | totrecorded(/ub) |
    +-------+------+-------+-------+-------------------+------------------+
    |   39  | 113  | 33792 | 33792 |   1812233429.720  |  1754342568.493  |
    +-------+------+-------+-------+-------------------+------------------+
  - Missing samples (compared to 7412_v2):
    - QCD_Pt-15to20_EMEnriched_TuneCUETP8M1_13TeV_pythia8
    - RSGravToGG_kMpl-001_M-1500_TuneCUEP8M1_13TeV-pythia8
    - RSGravToGG_kMpl-001_M-3000_TuneCUEP8M1_13TeV-pythia8
    - RSGravToGG_kMpl-001_M-7000_TuneCUEP8M1_13TeV-pythia8
    - RSGravToGG_kMpl-01_M-5000_TuneCUEP8M1_13TeV-pythia8
    - RSGravToGG_kMpl-01_M-6500_TuneCUEP8M1_13TeV-pythia8
- Private production of gen-only RSGravitons with 125GeV scan in mass and 10
  couplings points: 0.001, 0.002, 0.005, 0.007, 0.1, 0.15, 0.25, 0.35, 0.4, 0.6
  (~80% of the points finished correctly).
